### PR TITLE
feat: introduce navigation for switching between conversations

### DIFF
--- a/.opencode/commands/orchestrate.md
+++ b/.opencode/commands/orchestrate.md
@@ -30,8 +30,8 @@ Always use caveman.
     - Verify no untracked artifacts in .opencode/skills/
 7. **PR Fixes:**
     - Run a wait script: `bun -e "await new Promise(r => setTimeout(r, 20000))"`
-    - Check if PR checks are still running. 
-      - Yes? Re-run wait script.
-      - No? Are checks failing?
-        - No? Done.
-        - Yes? Check results, analyze and go back to step 4 to fix issues.
+    - Check if PR checks are still running.
+        - Yes? Re-run wait script.
+        - No? Are checks failing?
+            - No? Done.
+            - Yes? Check results, analyze and go back to step 4 to fix issues.

--- a/client/pages/main-page.js
+++ b/client/pages/main-page.js
@@ -92,7 +92,7 @@ class MainPage extends LitElement {
                         @mode-change=${this.handleModeChange}
                     ></chat-header>
                     <message-list
-                        .messages=${this.messages}
+                        .messages=${this.filteredMessages}
                         .loading=${this.loading}
                     ></message-list>
                     <chat-input
@@ -127,8 +127,20 @@ class MainPage extends LitElement {
         const text = e.detail.text;
         this.messages = [
             ...this.messages,
-            { id: String(this.messages.length + 1), role: "user", content: text, mode: this.mode },
+            {
+                id: String(this.messages.length + 1),
+                role: "user",
+                content: text,
+                mode: this.mode,
+                conversationId: this.activeConversationId,
+            },
         ];
+    }
+
+    get filteredMessages() {
+        return this.messages.filter(
+            (message) => message.conversationId === this.activeConversationId,
+        );
     }
 
     /** @param {CustomEvent<{ expanded: boolean }>} e */

--- a/client/pages/main-page.test.js
+++ b/client/pages/main-page.test.js
@@ -67,8 +67,16 @@ describe("main-page", () => {
         const conv2Messages = element.filteredMessages;
 
         expect(conv1Messages).not.toEqual(conv2Messages);
-        expect(conv1Messages.every((/** @type {{conversationId: string}} */ m) => m.conversationId === "1")).toBe(true);
-        expect(conv2Messages.every((/** @type {{conversationId: string}} */ m) => m.conversationId === "2")).toBe(true);
+        expect(
+            conv1Messages.every(
+                (/** @type {{conversationId: string}} */ m) => m.conversationId === "1",
+            ),
+        ).toBe(true);
+        expect(
+            conv2Messages.every(
+                (/** @type {{conversationId: string}} */ m) => m.conversationId === "2",
+            ),
+        ).toBe(true);
     });
 
     it("should switch mode correctly", () => {

--- a/client/pages/main-page.test.js
+++ b/client/pages/main-page.test.js
@@ -4,6 +4,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { MOCK_CONVERSATIONS, MOCK_MESSAGES } from "../utils/mock-data.js";
 
 describe("main-page", () => {
+    /** @type {any} */
     let element;
 
     beforeEach(() => {
@@ -66,8 +67,8 @@ describe("main-page", () => {
         const conv2Messages = element.filteredMessages;
 
         expect(conv1Messages).not.toEqual(conv2Messages);
-        expect(conv1Messages.every((m) => m.conversationId === "1")).toBe(true);
-        expect(conv2Messages.every((m) => m.conversationId === "2")).toBe(true);
+        expect(conv1Messages.every((/** @type {{conversationId: string}} */ m) => m.conversationId === "1")).toBe(true);
+        expect(conv2Messages.every((/** @type {{conversationId: string}} */ m) => m.conversationId === "2")).toBe(true);
     });
 
     it("should switch mode correctly", () => {

--- a/client/pages/main-page.test.js
+++ b/client/pages/main-page.test.js
@@ -1,68 +1,88 @@
-import { beforeEach, describe, expect, it } from "bun:test";
-
 import "./main-page.js";
+import { describe, it, expect, beforeEach } from "bun:test";
 
-describe("main-page sidebar", () => {
+import { MOCK_CONVERSATIONS, MOCK_MESSAGES } from "../utils/mock-data.js";
+
+describe("main-page", () => {
+    let element;
+
     beforeEach(() => {
         document.body.innerHTML = "";
+        element = document.createElement("main-page");
+        document.body.appendChild(element);
     });
 
-    function createPage() {
-        /** @type {any} */
-        const el = document.createElement("main-page");
-        document.body.appendChild(el);
-        return el;
-    }
-
-    it("passes sidebarExpanded to chat-sidebar", async () => {
-        const el = createPage();
-        el.sidebarExpanded = false;
-        await el.updateComplete;
-        const sidebar = el.shadowRoot.querySelector("chat-sidebar");
-        expect(sidebar.expanded).toBe(false);
+    it("should initialize with mock data", () => {
+        expect(element.conversations).toEqual(MOCK_CONVERSATIONS);
+        expect(element.messages).toEqual(MOCK_MESSAGES);
+        expect(element.activeConversationId).toBe("1");
     });
 
-    it("handles toggle-sidebar event from chat-sidebar", async () => {
-        const el = createPage();
-        await el.updateComplete;
-
-        const sidebar = el.shadowRoot.querySelector("chat-sidebar");
-        sidebar.dispatchEvent(
-            new CustomEvent("toggle-sidebar", {
-                detail: { expanded: false },
-                bubbles: true,
-                composed: true,
-            }),
+    it("should filter messages by active conversation", () => {
+        element.activeConversationId = "1";
+        expect(element.filteredMessages).toEqual(
+            MOCK_MESSAGES.filter((m) => m.conversationId === "1"),
         );
 
-        await el.updateComplete;
-        expect(el.sidebarExpanded).toBe(false);
-    });
-
-    it("updates sidebarExpanded state on toggle", async () => {
-        const el = createPage();
-        await el.updateComplete;
-
-        const sidebar = el.shadowRoot.querySelector("chat-sidebar");
-        sidebar.dispatchEvent(
-            new CustomEvent("toggle-sidebar", {
-                detail: { expanded: false },
-                bubbles: true,
-                composed: true,
-            }),
+        element.activeConversationId = "2";
+        expect(element.filteredMessages).toEqual(
+            MOCK_MESSAGES.filter((m) => m.conversationId === "2"),
         );
 
-        await el.updateComplete;
-        expect(el.sidebarExpanded).toBe(false);
+        element.activeConversationId = "3";
+        expect(element.filteredMessages).toEqual(
+            MOCK_MESSAGES.filter((m) => m.conversationId === "3"),
+        );
     });
 
-    it("passes messages and loading to message-list", async () => {
-        const el = createPage();
-        el.loading = true;
-        await el.updateComplete;
-        const messageList = el.shadowRoot.querySelector("message-list");
-        expect(messageList).toBeTruthy();
-        expect(messageList.loading).toBe(true);
-        expect(messageList.messages.length).toBeGreaterThan(0);
+    it("should return empty array for non-existent conversation", () => {
+        element.activeConversationId = "999";
+        expect(element.filteredMessages).toEqual([]);
+    });
+
+    it("should update activeConversationId when selecting conversation", () => {
+        const event = new CustomEvent("select-conversation", { detail: { id: "2" } });
+        element.handleSelectConversation(event);
+        expect(element.activeConversationId).toBe("2");
+    });
+
+    it("should add message with conversationId when sending", () => {
+        const initialLength = element.messages.length;
+        const event = new CustomEvent("send-message", { detail: { text: "Test message" } });
+        element.handleSendMessage(event);
+
+        expect(element.messages.length).toBe(initialLength + 1);
+        const newMessage = element.messages[element.messages.length - 1];
+        expect(newMessage.content).toBe("Test message");
+        expect(newMessage.role).toBe("user");
+        expect(newMessage.conversationId).toBe(element.activeConversationId);
+    });
+
+    it("should filter messages after switching conversations", () => {
+        element.activeConversationId = "1";
+        const conv1Messages = element.filteredMessages;
+
+        element.activeConversationId = "2";
+        const conv2Messages = element.filteredMessages;
+
+        expect(conv1Messages).not.toEqual(conv2Messages);
+        expect(conv1Messages.every((m) => m.conversationId === "1")).toBe(true);
+        expect(conv2Messages.every((m) => m.conversationId === "2")).toBe(true);
+    });
+
+    it("should switch mode correctly", () => {
+        expect(element.mode).toBe("player");
+
+        const event = new CustomEvent("mode-change", { detail: { mode: "gm" } });
+        element.handleModeChange(event);
+        expect(element.mode).toBe("gm");
+    });
+
+    it("should toggle sidebar", () => {
+        expect(element.sidebarExpanded).toBe(true);
+
+        const event = new CustomEvent("toggle-sidebar", { detail: { expanded: false } });
+        element.handleSidebarToggle(event);
+        expect(element.sidebarExpanded).toBe(false);
     });
 });

--- a/client/utils/mock-data.js
+++ b/client/utils/mock-data.js
@@ -9,11 +9,12 @@ const MOCK_CONVERSATIONS = [
 ];
 
 /** @type {Message[]} */
-const MOCK_MESSAGES = [
+const MOCK_MESSAGES_CONV_1 = [
     {
         id: "1",
         role: "user",
         mode: "gm",
+        conversationId: "1",
         content:
             "I'm a GM. My party just captured a mitflit king and wants to sell them at the market of a nearby settlement. How should I handle this?",
     },
@@ -21,6 +22,7 @@ const MOCK_MESSAGES = [
         id: "2",
         role: "assistant",
         mode: "gm",
+        conversationId: "1",
         blocks: [
             {
                 type: "paragraph",
@@ -93,6 +95,7 @@ const MOCK_MESSAGES = [
         id: "3",
         role: "user",
         mode: "gm",
+        conversationId: "1",
         content:
             "The blacksmith decided to buy the mitflit king. How could this affect the settlement's and the blacksmith's standing with the party? What else could happen to the mitflit king?",
     },
@@ -100,6 +103,7 @@ const MOCK_MESSAGES = [
         id: "4",
         role: "assistant",
         mode: "gm",
+        conversationId: "1",
         blocks: [
             {
                 type: "paragraph",
@@ -134,6 +138,7 @@ const MOCK_MESSAGES = [
         id: "5",
         role: "user",
         mode: "player",
+        conversationId: "1",
         content:
             "My fighter just got crit by a giant scorpion. How do I calculate the damage if I have resistance 5 to physical?",
     },
@@ -141,6 +146,7 @@ const MOCK_MESSAGES = [
         id: "6",
         role: "assistant",
         mode: "player",
+        conversationId: "1",
         blocks: [
             {
                 type: "paragraph",
@@ -170,5 +176,207 @@ const MOCK_MESSAGES = [
         ],
     },
 ];
+
+/** @type {Message[]} */
+const MOCK_MESSAGES_CONV_2 = [
+    {
+        id: "7",
+        role: "user",
+        mode: "gm",
+        conversationId: "2",
+        content:
+            "My rogue wants to assassinate a noble by cutting the rope of a massive chandelier above them. What should I ask for in terms of checks?",
+    },
+    {
+        id: "8",
+        role: "assistant",
+        mode: "gm",
+        conversationId: "2",
+        blocks: [
+            {
+                type: "paragraph",
+                segments: [
+                    {
+                        text: "This is a creative improvised action! Here's how to handle it:",
+                    },
+                ],
+            },
+            {
+                type: "callout",
+                title: "Skill Checks Needed",
+                segments: [
+                    {
+                        text: "1. ",
+                    },
+                    { text: "Thievery (DC 18)", highlight: true },
+                    {
+                        text: " - to cut or weaken the rope unnoticed",
+                    },
+                    { text: "2. ", highlight: true },
+                    { text: "Stealth (DC 20)", highlight: true },
+                    {
+                        text: " - to position themselves without detection",
+                    },
+                    { text: "3. ", highlight: true },
+                    { text: "Timing check", highlight: true },
+                    {
+                        text: " - a free action to release when the noble is under it",
+                    },
+                ],
+            },
+            {
+                type: "paragraph",
+                text: "If all succeed, deal 6d6 bludgeoning damage (DC 20 Reflex for half). If spotted early, guards intervene.",
+            },
+        ],
+    },
+    {
+        id: "9",
+        role: "user",
+        mode: "gm",
+        conversationId: "2",
+        content:
+            "What if the noble notices and orders guards to attack? The rogue is on the rafters.",
+    },
+    {
+        id: "10",
+        role: "assistant",
+        mode: "gm",
+        conversationId: "2",
+        blocks: [
+            {
+                type: "paragraph",
+                text: "This becomes a dynamic chase scene! Consider these complications:",
+            },
+            {
+                type: "list",
+                items: [
+                    {
+                        title: "Rafter Terrain:",
+                        text: "Narrow, unstable surfaces. Acrobatics DC 15 to move without falling (10 ft fall damage). Guards have -2 to attack.",
+                    },
+                    {
+                        title: "The Chandelier:",
+                        segments: [
+                            { text: "If the rogue cuts it now, they can drop it on " },
+                            { text: "1d4 guards below", highlight: true },
+                            { text: " for the same damage." },
+                        ],
+                    },
+                    {
+                        title: "Escape Options:",
+                        text: "Through a window (Athletics DC 12 to climb out), down a nearby servant's stair, or use a grappling hook to swing to a balcony.",
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+/** @type {Message[]} */
+const MOCK_MESSAGES_CONV_3 = [
+    {
+        id: "11",
+        role: "user",
+        mode: "player",
+        conversationId: "3",
+        content:
+            "I'm playing a wizard and need to buy dragon's blood for my potion research. Where can I find it and what should it cost?",
+    },
+    {
+        id: "12",
+        role: "assistant",
+        mode: "player",
+        conversationId: "3",
+        blocks: [
+            {
+                type: "paragraph",
+                segments: [
+                    {
+                        text: "Dragon's blood is a rare alchemical reagent. Here's how to handle it in your campaign:",
+                    },
+                ],
+            },
+            {
+                type: "callout",
+                title: "Availability & Cost",
+                segments: [
+                    {
+                        text: "In a major settlement with a magic district, treat it as ",
+                    },
+                    { text: "Level 5 rare item", highlight: true },
+                    {
+                        text: ". Base cost: 25 gp per vial (enough for 1 potion or 2 scrolls).",
+                    },
+                ],
+            },
+            {
+                type: "callout",
+                title: "Purchase Options",
+                segments: [
+                    {
+                        text: "1. ",
+                    },
+                    { text: "Alchemist's Shop", highlight: true },
+                    {
+                        text: " - DC 22 Diplomacy to find a supplier",
+                    },
+                    { text: "2. ", highlight: true },
+                    { text: "Black Market", highlight: true },
+                    {
+                        text: " - DC 20 Underworld check, but watch for shady dealings",
+                    },
+                ],
+            },
+            {
+                type: "paragraph",
+                text: "Your GM might require you to hunt a dragon yourself as a quest instead of buying it!",
+            },
+        ],
+    },
+    {
+        id: "13",
+        role: "user",
+        mode: "player",
+        conversationId: "3",
+        content: "What level of dragon would have blood usable for a wizard's research?",
+    },
+    {
+        id: "14",
+        role: "assistant",
+        mode: "player",
+        conversationId: "3",
+        blocks: [
+            {
+                type: "paragraph",
+                text: "Most dragon blood is usable, but the quality affects potency:",
+            },
+            {
+                type: "list",
+                items: [
+                    {
+                        title: "Young or Adult Dragon:",
+                        text: "Standard quality. Good for basic potions and scrolls. Blood harvested after death.",
+                    },
+                    {
+                        title: "Ancient Dragon:",
+                        segments: [
+                            { text: "Superior quality. Grants a " },
+                            { text: "+1 item bonus", highlight: true },
+                            { text: " on crafting checks using this reagent." },
+                        ],
+                    },
+                    {
+                        title: "Extraction Method:",
+                        text: "Non-lethal extraction is possible (Athletics or Medicine DC equal to dragon's Fortitude save) but yields 50% less blood and the dragon remembers...",
+                    },
+                ],
+            },
+        ],
+    },
+];
+
+/** @type {Message[]} */
+const MOCK_MESSAGES = [...MOCK_MESSAGES_CONV_1, ...MOCK_MESSAGES_CONV_2, ...MOCK_MESSAGES_CONV_3];
 
 export { MOCK_CONVERSATIONS, MOCK_MESSAGES };

--- a/client/utils/mock-data.test.js
+++ b/client/utils/mock-data.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "bun:test";
+
+import { MOCK_CONVERSATIONS, MOCK_MESSAGES } from "./mock-data.js";
+
+describe("mock-data", () => {
+    describe("MOCK_CONVERSATIONS", () => {
+        it("should have 3 conversations", () => {
+            expect(MOCK_CONVERSATIONS).toHaveLength(3);
+        });
+
+        it("should have conversation with id '1'", () => {
+            const conv1 = MOCK_CONVERSATIONS.find((c) => c.id === "1");
+            expect(conv1).toBeDefined();
+            expect(conv1?.title).toBe("Mitflit King Capture");
+        });
+
+        it("should have conversation with id '2'", () => {
+            const conv2 = MOCK_CONVERSATIONS.find((c) => c.id === "2");
+            expect(conv2).toBeDefined();
+            expect(conv2?.title).toBe("Chandelier Assassination");
+        });
+
+        it("should have conversation with id '3'", () => {
+            const conv3 = MOCK_CONVERSATIONS.find((c) => c.id === "3");
+            expect(conv3).toBeDefined();
+            expect(conv3?.title).toBe("Buying rare reagents");
+        });
+    });
+
+    describe("MOCK_MESSAGES", () => {
+        it("should have messages for all conversations", () => {
+            const conv1Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "1");
+            const conv2Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "2");
+            const conv3Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "3");
+
+            expect(conv1Messages.length).toBeGreaterThan(0);
+            expect(conv2Messages.length).toBeGreaterThan(0);
+            expect(conv3Messages.length).toBeGreaterThan(0);
+        });
+
+        it("should have at least 4 messages for conversation 1", () => {
+            const conv1Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "1");
+            expect(conv1Messages.length).toBeGreaterThanOrEqual(4);
+        });
+
+        it("should have at least 2 messages for conversation 2", () => {
+            const conv2Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "2");
+            expect(conv2Messages.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it("should have at least 2 messages for conversation 3", () => {
+            const conv3Messages = MOCK_MESSAGES.filter((m) => m.conversationId === "3");
+            expect(conv3Messages.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it("should have all messages with conversationId", () => {
+            const messagesWithoutConversationId = MOCK_MESSAGES.filter((m) => !m.conversationId);
+            expect(messagesWithoutConversationId).toHaveLength(0);
+        });
+
+        it("should have valid message structure", () => {
+            MOCK_MESSAGES.forEach((message) => {
+                expect(message).toHaveProperty("id");
+                expect(message).toHaveProperty("role");
+                expect(message).toHaveProperty("conversationId");
+                expect(["user", "assistant"]).toContain(message.role);
+            });
+        });
+    });
+});

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,53 @@ import { Hono } from "hono";
 import { serveStatic } from "hono/bun";
 import z from "zod";
 
+import { MOCK_CONVERSATIONS, MOCK_MESSAGES } from "../client/utils/mock-data.js";
+import {
+    conversationIdSchema,
+    createConversationSchema,
+    createMessageSchema,
+} from "../shared/schemas.js";
+
 const app = new Hono()
+    .get("/api/conversations", (c) => {
+        return c.json(MOCK_CONVERSATIONS);
+    })
+    .get(
+        "/api/conversations/:id/messages",
+        zValidator("param", z.object({ id: conversationIdSchema })),
+        (c) => {
+            const { id } = c.req.valid("param");
+            const messages = MOCK_MESSAGES.filter((message) => message.conversationId === id);
+            return c.json(messages);
+        },
+    )
+    .post("/api/conversations", zValidator("json", createConversationSchema), (c) => {
+        const data = c.req.valid("json");
+        const newConversation = {
+            id: String(MOCK_CONVERSATIONS.length + 1),
+            title: data.title,
+        };
+        MOCK_CONVERSATIONS.push(newConversation);
+        return c.json(newConversation, 201);
+    })
+    .post(
+        "/api/conversations/:id/messages",
+        zValidator("param", z.object({ id: conversationIdSchema })),
+        zValidator("json", createMessageSchema),
+        (c) => {
+            const { id } = c.req.valid("param");
+            const data = c.req.valid("json");
+            const newMessage = {
+                id: String(MOCK_MESSAGES.length + 1),
+                role: "user",
+                content: data.content,
+                mode: data.mode,
+                conversationId: id,
+            };
+            MOCK_MESSAGES.push(newMessage);
+            return c.json(newMessage, 201);
+        },
+    )
     .get("/api/query", zValidator("query", z.object({ foo: z.string() })), (c) => {
         return c.json({ message: "Hello, World... oh!" + c.req.valid("query").foo });
     })

--- a/server/index.js
+++ b/server/index.js
@@ -39,6 +39,7 @@ const app = new Hono()
         (c) => {
             const { id } = c.req.valid("param");
             const data = c.req.valid("json");
+            /** @type {{ id: string, role: "user", content: string, mode: "player" | "gm", conversationId: string }} */
             const newMessage = {
                 id: String(MOCK_MESSAGES.length + 1),
                 role: "user",

--- a/shared/schemas.js
+++ b/shared/schemas.js
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+const conversationIdSchema = z.string().uuid().or(z.string().regex(/^\d+$/));
+
+const messageSchema = z.object({
+    id: z.string(),
+    role: z.enum(["user", "assistant"]),
+    mode: z.enum(["player", "gm"]),
+    conversationId: z.string().optional(),
+    content: z.string().optional(),
+    blocks: z.array(z.any()).optional(),
+});
+
+const conversationSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+});
+
+const createConversationSchema = z.object({
+    title: z.string().min(1).max(200),
+});
+
+const createMessageSchema = z.object({
+    content: z.string().min(1),
+    mode: z.enum(["player", "gm"]),
+});
+
+export {
+    conversationIdSchema,
+    messageSchema,
+    conversationSchema,
+    createConversationSchema,
+    createMessageSchema,
+};

--- a/shared/types.js
+++ b/shared/types.js
@@ -46,9 +46,9 @@
 
 /** @typedef {ParagraphBlock | CalloutBlock | StatBlockMessageBlock | ListBlock} MessageBlock */
 
-/** @typedef {{ id: string, role: "user", content: string, mode: Mode }} UserMessage */
+/** @typedef {{ id: string, role: "user", content: string, mode: Mode, conversationId?: string }} UserMessage */
 
-/** @typedef {{ id: string, role: "assistant", blocks: MessageBlock[], mode: Mode }} AssistantMessage */
+/** @typedef {{ id: string, role: "assistant", blocks: MessageBlock[], mode: Mode, conversationId?: string }} AssistantMessage */
 
 /** @typedef {UserMessage | AssistantMessage} Message */
 

--- a/vrtests/navigation.spec.js
+++ b/vrtests/navigation.spec.js
@@ -55,19 +55,15 @@ test.describe("navigation e2e tests", () => {
 
         await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
         await page.waitForTimeout(500);
-        const conv1FirstMessageText = await messageList.locator("chat-message").first().textContent();
+        await expect(messageList.locator("chat-message").first()).toContainText(/mitflit/i);
 
         await sidebar.locator("conversation-item", { hasText: "Chandelier Assassination" }).click();
         await page.waitForTimeout(500);
-        const conv2FirstMessageText = await messageList.locator("chat-message").first().textContent();
+        await expect(messageList.locator("chat-message").first()).toContainText(/chandelier/i);
 
         await sidebar.locator("conversation-item", { hasText: "Buying rare reagents" }).click();
         await page.waitForTimeout(500);
-        const conv3FirstMessageText = await messageList.locator("chat-message").first().textContent();
-
-        expect(conv1FirstMessageText).not.toEqual(conv2FirstMessageText);
-        expect(conv2FirstMessageText).not.toEqual(conv3FirstMessageText);
-        expect(conv1FirstMessageText).not.toEqual(conv3FirstMessageText);
+        await expect(messageList.locator("chat-message").first()).toContainText(/dragon/i);
 
         await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
         await page.waitForTimeout(500);

--- a/vrtests/navigation.spec.js
+++ b/vrtests/navigation.spec.js
@@ -1,0 +1,147 @@
+import { expect, test } from "playwright/test";
+
+test.describe("navigation e2e tests", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/");
+        await page.waitForSelector("main-page");
+        await page.waitForTimeout(1000);
+    });
+
+    test("load page with conversation 1 active and verify messages", async ({ page }) => {
+        const messageList = page.locator("message-list");
+        await expect(messageList).toBeVisible();
+
+        const messages = messageList.locator("chat-message");
+        const messageCount = await messages.count();
+        expect(messageCount).toBeGreaterThan(0);
+
+        const firstMessage = messages.first();
+        await expect(firstMessage).toContainText(/mitflit king/i);
+    });
+
+    test("switch to conversation 2 and verify messages change", async ({ page }) => {
+        const messageList = page.locator("message-list");
+        const initialMessageCount = await messageList.locator("chat-message").count();
+
+        const sidebar = page.locator("chat-sidebar");
+        await sidebar.locator("conversation-item", { hasText: "Chandelier Assassination" }).click();
+        await page.waitForTimeout(500);
+
+        const newMessageCount = await messageList.locator("chat-message").count();
+        expect(newMessageCount).toBeLessThan(initialMessageCount);
+
+        const firstMessage = messageList.locator("chat-message").first();
+        await expect(firstMessage).toContainText(/chandelier/i);
+    });
+
+    test("switch to conversation 3 and verify messages change", async ({ page }) => {
+        const messageList = page.locator("message-list");
+        const initialMessageCount = await messageList.locator("chat-message").count();
+
+        const sidebar = page.locator("chat-sidebar");
+        await sidebar.locator("conversation-item", { hasText: "Buying rare reagents" }).click();
+        await page.waitForTimeout(500);
+
+        const newMessageCount = await messageList.locator("chat-message").count();
+        expect(newMessageCount).toBeLessThan(initialMessageCount);
+
+        const firstMessage = messageList.locator("chat-message").first();
+        await expect(firstMessage).toContainText(/dragon/i);
+    });
+
+    test("switch between conversations and verify messages switch correctly", async ({ page }) => {
+        const messageList = page.locator("message-list");
+        const sidebar = page.locator("chat-sidebar");
+
+        await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
+        await page.waitForTimeout(500);
+        const conv1FirstMessage = messageList.locator("chat-message").first();
+
+        await sidebar.locator("conversation-item", { hasText: "Chandelier Assassination" }).click();
+        await page.waitForTimeout(500);
+        const conv2FirstMessage = messageList.locator("chat-message").first();
+
+        await sidebar.locator("conversation-item", { hasText: "Buying rare reagents" }).click();
+        await page.waitForTimeout(500);
+        const conv3FirstMessage = messageList.locator("chat-message").first();
+
+        await expect(conv1FirstMessage).not.toEqual(conv2FirstMessage);
+        await expect(conv2FirstMessage).not.toEqual(conv3FirstMessage);
+        await expect(conv1FirstMessage).not.toEqual(conv3FirstMessage);
+
+        await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
+        await page.waitForTimeout(500);
+        const backToConv1FirstMessage = messageList.locator("chat-message").first();
+        await expect(backToConv1FirstMessage).toContainText(/mitflit king/i);
+    });
+
+    test("send message and verify it appears in active conversation", async ({ page }) => {
+        const messageList = page.locator("message-list");
+        const initialCount = await messageList.locator("chat-message").count();
+
+        const input = page.locator("chat-input textarea");
+        await input.fill("This is a test message");
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+
+        const newCount = await messageList.locator("chat-message").count();
+        expect(newCount).toBe(initialCount + 1);
+
+        const lastMessage = messageList.locator("chat-message").last();
+        await expect(lastMessage).toContainText("This is a test message");
+    });
+
+    test("switch conversations and verify new message only in original conversation", async ({
+        page,
+    }) => {
+        const messageList = page.locator("message-list");
+        const input = page.locator("chat-input textarea");
+        const sidebar = page.locator("chat-sidebar");
+
+        await input.fill("Test message for conv 1");
+        await page.keyboard.press("Enter");
+        await page.waitForTimeout(1000);
+
+        const conv1Count = await messageList.locator("chat-message").count();
+
+        await sidebar.locator("conversation-item", { hasText: "Chandelier Assassination" }).click();
+        await page.waitForTimeout(500);
+
+        const conv2Count = await messageList.locator("chat-message").count();
+        expect(conv2Count).not.toBe(conv1Count);
+
+        const messages = messageList.locator("chat-message");
+        const hasTestMessage = await messages.count();
+        expect(hasTestMessage).toBeGreaterThan(0);
+
+        const lastMessage = messageList.locator("chat-message").last();
+        await expect(lastMessage).not.toContainText("Test message for conv 1");
+
+        await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
+        await page.waitForTimeout(500);
+
+        const backToConv1Count = await messageList.locator("chat-message").count();
+        expect(backToConv1Count).toBe(conv1Count);
+    });
+
+    test("search filters conversation list", async ({ page }) => {
+        const sidebar = page.locator("chat-sidebar");
+        const searchInput = sidebar.locator(
+            'sl-input[placeholder="Search conversations..."] input',
+        );
+
+        await searchInput.fill("Mitflit");
+        await page.waitForTimeout(300);
+
+        const visibleItems = sidebar.locator("conversation-item:not([hidden])");
+        const count = await visibleItems.count();
+        expect(count).toBe(1);
+
+        await searchInput.fill("");
+        await page.waitForTimeout(300);
+
+        const allItems = sidebar.locator("conversation-item:not([hidden])");
+        const allCount = await allItems.count();
+        expect(allCount).toBe(3);
+    });
+});

--- a/vrtests/navigation.spec.js
+++ b/vrtests/navigation.spec.js
@@ -55,19 +55,19 @@ test.describe("navigation e2e tests", () => {
 
         await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
         await page.waitForTimeout(500);
-        const conv1FirstMessage = messageList.locator("chat-message").first();
+        const conv1FirstMessageText = await messageList.locator("chat-message").first().textContent();
 
         await sidebar.locator("conversation-item", { hasText: "Chandelier Assassination" }).click();
         await page.waitForTimeout(500);
-        const conv2FirstMessage = messageList.locator("chat-message").first();
+        const conv2FirstMessageText = await messageList.locator("chat-message").first().textContent();
 
         await sidebar.locator("conversation-item", { hasText: "Buying rare reagents" }).click();
         await page.waitForTimeout(500);
-        const conv3FirstMessage = messageList.locator("chat-message").first();
+        const conv3FirstMessageText = await messageList.locator("chat-message").first().textContent();
 
-        await expect(conv1FirstMessage).not.toEqual(conv2FirstMessage);
-        await expect(conv2FirstMessage).not.toEqual(conv3FirstMessage);
-        await expect(conv1FirstMessage).not.toEqual(conv3FirstMessage);
+        expect(conv1FirstMessageText).not.toEqual(conv2FirstMessageText);
+        expect(conv2FirstMessageText).not.toEqual(conv3FirstMessageText);
+        expect(conv1FirstMessageText).not.toEqual(conv3FirstMessageText);
 
         await sidebar.locator("conversation-item", { hasText: "Mitflit King Capture" }).click();
         await page.waitForTimeout(500);


### PR DESCRIPTION
## Summary
- Add conversation switching functionality with message filtering by conversation ID
- Update mock data to include multiple conversations with distinct messages
- Add API endpoints for fetching and managing conversations
- Add comprehensive unit tests for navigation and filtering logic
- Add visual regression tests for conversation switching flow
- Support sending messages that are scoped to the active conversation

## Technical Details
- Client: Add `filteredMessages` getter to `main-page.js` that filters messages by `activeConversationId`
- Client: Update `handleSendMessage` to include `conversationId` when creating new messages
- Shared: Add `conversationId` field to `Message` type definitions
- Server: Add REST endpoints for conversations (`GET /api/conversations`, `GET /api/conversations/:id/messages`, `POST /api/conversations`, `POST /api/conversations/:id/messages`)
- Tests: Add unit tests for message filtering, conversation switching, and mock data structure
- Tests: Add Playwright e2e tests covering conversation switching, message sending, and search functionality