### PR TITLE
introduce @lit/context store architecture to decouple main-page (#39)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "pathfinder-librarian",
       "dependencies": {
         "@hono/zod-validator": "0.7.6",
+        "@lit/context": "1.1.2",
         "@shoelace-style/shoelace": "2.20.1",
         "@simplewebauthn/browser": "13.3.0",
         "@simplewebauthn/server": "13.3.0",
@@ -52,6 +53,8 @@
     "@levischuck/tiny-cbor": ["@levischuck/tiny-cbor@0.2.11", "", {}, "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
+
+    "@lit/context": ["@lit/context@1.1.2", "", { "dependencies": { "@lit/reactive-element": "^1.6.2 || ^2.0.0" } }, "sha512-S0nw2C6Tkm7fVX5TGYqeROGD+Z9Coa2iFpW+ysYBDH3YvCqOY3wVQvSgwbaliLJkjTnSEYCBe9qFqKV8WUFpVw=="],
 
     "@lit/react": ["@lit/react@1.0.8", "", { "peerDependencies": { "@types/react": "17 || 18 || 19" } }, "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw=="],
 

--- a/client/components/chat-header.js
+++ b/client/components/chat-header.js
@@ -10,7 +10,6 @@ import { tokens } from "../styles/tokens.js";
 
 /**
  * @customElement chat-header
- * @property {Mode} mode - The current mode of the application (GM or Player).
  * @fires mode-change - Fired when the user changes the mode using the mode toggle.
  */
 class ChatHeader extends LitElement {
@@ -47,14 +46,8 @@ class ChatHeader extends LitElement {
         `,
     ];
 
-    static properties = {
-        mode: { type: String },
-    };
-
     constructor() {
         super();
-        /** @type {Mode} */
-        this.mode = "player";
     }
 
     render() {
@@ -64,7 +57,7 @@ class ChatHeader extends LitElement {
                     <span class="title">Pathfinder 2e</span>
                     <span class="subtitle">Rules Assistant</span>
                 </div>
-                <mode-toggle .mode=${this.mode} @mode-change=${this.handleModeChange}></mode-toggle>
+                <mode-toggle @mode-change=${this.handleModeChange}></mode-toggle>
             </header>
         `;
     }
@@ -73,7 +66,6 @@ class ChatHeader extends LitElement {
      * @param {CustomEvent<{ mode: Mode }>} e
      */
     handleModeChange(e) {
-        this.mode = e.detail.mode;
         this.dispatchEvent(
             new CustomEvent("mode-change", {
                 detail: { mode: e.detail.mode },

--- a/client/components/chat-header.test.js
+++ b/client/components/chat-header.test.js
@@ -8,11 +8,9 @@ describe("chat-header", () => {
         document.body.innerHTML = "";
     });
 
-    /** @param {string} mode */
-    function createHeader(mode = "player") {
+    function createHeader() {
         /** @type {any} */
         const el = document.createElement("chat-header");
-        el.mode = mode;
         document.body.appendChild(el);
         return el;
     }
@@ -36,15 +34,8 @@ describe("chat-header", () => {
         expect(toggle).toBeTruthy();
     });
 
-    it("passes mode to mode-toggle", async () => {
-        const el = createHeader("gm");
-        await el.updateComplete;
-        const toggle = /** @type {any} */ (el.shadowRoot.querySelector("mode-toggle"));
-        expect(toggle.mode).toBe("gm");
-    });
-
     it("dispatches mode-change when mode-toggle fires mode-change", async () => {
-        const el = createHeader("player");
+        const el = createHeader();
         await el.updateComplete;
 
         /** @type {any} */
@@ -70,22 +61,5 @@ describe("chat-header", () => {
         if (detail) {
             expect(detail.mode).toBe("gm");
         }
-    });
-
-    it("updates own mode when mode-toggle fires mode-change", async () => {
-        const el = createHeader("player");
-        await el.updateComplete;
-
-        const toggle = /** @type {any} */ (el.shadowRoot.querySelector("mode-toggle"));
-        toggle.dispatchEvent(
-            new CustomEvent("mode-change", {
-                detail: { mode: "gm" },
-                bubbles: true,
-                composed: true,
-            }),
-        );
-
-        await el.updateComplete;
-        expect(el.mode).toBe("gm");
     });
 });

--- a/client/components/chat-input.js
+++ b/client/components/chat-input.js
@@ -1,8 +1,11 @@
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/textarea/textarea.js?deps=lit@3.3.2";
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { messagesContext } from "../stores/messages-store.js";
+import { modeContext } from "../stores/mode-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
@@ -11,12 +14,9 @@ import { tokens } from "../styles/tokens.js";
  * @typedef {InputEvent & { currentTarget: T }} TargetedInputEvent
  */
 
-/** @typedef {import("../../shared/types.js").Mode} Mode */
-
 /**
  * @customElement chat-input
  * @property {string} value - The current value of the chat input.
- * @property {Mode} mode - The current mode of the application (GM or Player).
  * @fires send-message - Fired when the user submits a message, with the message text in the event detail.
  */
 class ChatInput extends LitElement {
@@ -97,19 +97,15 @@ class ChatInput extends LitElement {
 
     static properties = {
         value: { type: String },
-        mode: { type: String },
-        // Whether the assistant is currently responding. When true the
-        // submit button becomes a Stop button and will dispatch `stop-message`.
-        responding: { type: Boolean, reflect: true },
     };
 
     constructor() {
         super();
         this.value = "";
-        /** @type {Mode} */
-        this.mode = "gm";
-        /** @type {boolean} */
-        this.responding = false;
+        /** @type {import("../stores/mode-store.js").ModeState} */
+        this._modeState = { mode: "gm" };
+        /** @type {import("../stores/messages-store.js").MessagesState} */
+        this._msgState = { messages: [], responding: false };
         document.addEventListener("select-conversation", () => {
             const textarea = /** @type {HTMLTextAreaElement | null} */ (
                 this.shadowRoot?.querySelector("sl-textarea")
@@ -118,10 +114,28 @@ class ChatInput extends LitElement {
         });
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: modeContext,
+            callback: /** @param {import("../stores/mode-store.js").ModeState} v */ (v) => {
+                this._modeState = v;
+            },
+            subscribe: true,
+        });
+        new ContextConsumer(this, {
+            context: messagesContext,
+            callback: /** @param {import("../stores/messages-store.js").MessagesState} v */ (v) => {
+                this._msgState = v;
+            },
+            subscribe: true,
+        });
+    }
+
     render() {
         return html`
             <div class="wrapper">
-                <div class="input-row" data-mode=${this.mode}>
+                <div class="input-row" data-mode=${this._modeState.mode}>
                     <sl-textarea
                         .value=${this.value}
                         @sl-input=${this.handleInput}
@@ -133,7 +147,7 @@ class ChatInput extends LitElement {
                         autofocus
                         data-test="composer-input"
                     ></sl-textarea>
-                    ${this.responding
+                    ${this._msgState.responding
                         ? html`
                               <button @click=${this.handleStop} class="send-btn stop">Stop</button>
                           `
@@ -180,7 +194,7 @@ class ChatInput extends LitElement {
     }
 
     handleSubmit() {
-        if (this.responding) {
+        if (this._msgState.responding) {
             return;
         }
         const text = this.value.trim();

--- a/client/components/chat-input.test.js
+++ b/client/components/chat-input.test.js
@@ -84,9 +84,9 @@ describe("chat-input", () => {
         expect(dispatched).toBe(false);
     });
 
-    it("does not dispatch send-message when disabled", async () => {
+    it("does not dispatch send-message when disabled (responding is true)", async () => {
         const el = createInput();
-        el.responding = true;
+        el._msgState = { messages: [], responding: true };
         await el.updateComplete;
 
         el.value = "Hello";
@@ -105,7 +105,7 @@ describe("chat-input", () => {
 
     it("renders stop button when responding", async () => {
         const el = createInput();
-        el.responding = true;
+        el._msgState = { messages: [], responding: true };
         await el.updateComplete;
 
         const stop = Array.from(el.shadowRoot.querySelectorAll("button")).find((b) =>

--- a/client/components/chat-sidebar.js
+++ b/client/components/chat-sidebar.js
@@ -3,22 +3,20 @@ import "./new-chat-button.js";
 import "./session-list.js";
 import "./sidebar-profile.js";
 import "./conversation-menu.js";
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { conversationContext } from "../stores/conversation-store.js";
+import { modeContext } from "../stores/mode-store.js";
+import { uiContext } from "../stores/ui-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
-/** @typedef {import("../../shared/types.js").Conversation} Conversation */
-/** @typedef {import("../../shared/types.js").Mode} Mode */
-
 /**
  * @customElement chat-sidebar
- * @property {Conversation[]} conversations - The list of conversations to display in the sidebar.
- * @property {string} activeId - The ID of the currently active conversation.
- * @property {Mode} mode - The current mode of the application (GM or Player).
- * @property {boolean} expanded - Whether the sidebar is expanded or collapsed.
+ * @property {import("../../shared/types.js").AuthUser | null} user - The authenticated user object.
  */
 class ChatSidebar extends LitElement {
     static styles = [
@@ -94,24 +92,47 @@ class ChatSidebar extends LitElement {
     ];
 
     static properties = {
-        conversations: { type: Array },
-        activeId: { type: String },
-        mode: { type: String },
-        expanded: { type: Boolean },
         user: { type: Object },
     };
 
     constructor() {
         super();
-        /** @type {Conversation[]} */
-        this.conversations = [];
-        /** @type {string} */
-        this.activeId = "";
-        /** @type {Mode} */
-        this.mode = "gm";
-        this.expanded = true;
         /** @type {import("../../shared/types.js").AuthUser | null} */
         this.user = null;
+        /** @type {import("../stores/conversation-store.js").ConversationState} */
+        this._convState = { conversations: [], activeConversationId: "", loading: true };
+        /** @type {import("../stores/mode-store.js").ModeState} */
+        this._modeState = { mode: "gm" };
+        /** @type {import("../stores/ui-store.js").UIState} */
+        this._uiState = { sidebarExpanded: true, settingsOpen: false };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: conversationContext,
+            callback:
+                /** @param {import("../stores/conversation-store.js").ConversationState} v */ (
+                    v,
+                ) => {
+                    this._convState = v;
+                },
+            subscribe: true,
+        });
+        new ContextConsumer(this, {
+            context: modeContext,
+            callback: /** @param {import("../stores/mode-store.js").ModeState} v */ (v) => {
+                this._modeState = v;
+            },
+            subscribe: true,
+        });
+        new ContextConsumer(this, {
+            context: uiContext,
+            callback: /** @param {import("../stores/ui-store.js").UIState} v */ (v) => {
+                this._uiState = v;
+            },
+            subscribe: true,
+        });
     }
 
     /**
@@ -121,54 +142,34 @@ class ChatSidebar extends LitElement {
      * @returns {import("lit-html").TemplateResult}
      */
     render() {
+        const expanded = this._uiState.sidebarExpanded;
         return html`
-            <aside class="sidebar ${!this.expanded ? "collapsed" : ""}">
+            <aside class="sidebar ${!expanded ? "collapsed" : ""}">
                 <div class="toggle-container">
                     <sidebar-toggle
-                        .expanded=${this.expanded}
+                        .expanded=${expanded}
                         @toggle-sidebar=${this.handleToggle}
                     ></sidebar-toggle>
                 </div>
-                <new-chat-button ?collapsed=${!this.expanded}></new-chat-button>
+                <new-chat-button ?collapsed=${!expanded}></new-chat-button>
                 <div class="content-container">
-                    <div class="content ${!this.expanded ? "collapsed" : ""}">
-                        <session-list
-                            .mode=${this.mode}
-                            .conversations=${this.conversations}
-                            .activeId=${this.activeId}
-                            @select-conversation=${this.handleSelectConversation}
-                        ></session-list>
+                    <div class="content ${!expanded ? "collapsed" : ""}">
+                        <session-list></session-list>
                     </div>
-                    <div class="conversation-menu-wrapper ${!this.expanded ? "visible" : ""}">
-                        <conversation-menu
-                            .conversations=${this.conversations}
-                            .activeId=${this.activeId}
-                            .mode=${this.mode}
-                            @select-conversation=${this.handleSelectConversation}
-                        ></conversation-menu>
+                    <div class="conversation-menu-wrapper ${!expanded ? "visible" : ""}">
+                        <conversation-menu></conversation-menu>
                     </div>
                 </div>
-                <sidebar-profile
-                    .mode=${this.mode}
-                    .user=${this.user}
-                    ?collapsed=${!this.expanded}
-                ></sidebar-profile>
+                <sidebar-profile .user=${this.user} ?collapsed=${!expanded}></sidebar-profile>
             </aside>
         `;
     }
 
-    /**
-     * @param {CustomEvent<{ id: string }>} e
-     */
-    handleSelectConversation(e) {
-        this.activeId = e.detail.id;
-    }
-
     handleToggle() {
-        this.expanded = !this.expanded;
+        const newExpanded = !this._uiState.sidebarExpanded;
         this.dispatchEvent(
             new CustomEvent("toggle-sidebar", {
-                detail: { expanded: this.expanded },
+                detail: { expanded: newExpanded },
                 bubbles: true,
                 composed: true,
             }),

--- a/client/components/chat-sidebar.test.js
+++ b/client/components/chat-sidebar.test.js
@@ -12,8 +12,9 @@ describe("chat-sidebar", () => {
     function createSidebar(conversations = [], activeId = "") {
         /** @type {any} */
         const el = document.createElement("chat-sidebar");
-        el.conversations = conversations;
-        el.activeId = activeId;
+        el._convState = { conversations, activeConversationId: activeId, loading: false };
+        el._modeState = { mode: "gm" };
+        el._uiState = { sidebarExpanded: true, settingsOpen: false };
         document.body.appendChild(el);
         return el;
     }
@@ -30,7 +31,6 @@ describe("chat-sidebar", () => {
         await el.updateComplete;
         const list = el.shadowRoot.querySelector("session-list");
         expect(list).toBeTruthy();
-        expect(list.conversations).toHaveLength(1);
     });
 
     it("renders sidebar-profile component", async () => {
@@ -51,15 +51,6 @@ describe("chat-sidebar", () => {
         expect(profile.name).toBe("Game Master 01");
         expect(profile.subtitle).toBe("PF2e Remaster Rules");
         expect(profile.initials).toBe("GM");
-    });
-
-    it("passes conversations and activeId to session-list", async () => {
-        const el = createSidebar([{ id: "1", title: "Active Chat" }], "1");
-        await el.updateComplete;
-        const list = el.shadowRoot.querySelector("session-list");
-        expect(list).toBeTruthy();
-        expect(list.conversations).toHaveLength(1);
-        expect(list.activeId).toBe("1");
     });
 
     it("dispatches new-chat on button click", async () => {
@@ -104,41 +95,18 @@ describe("chat-sidebar", () => {
         }
     });
 
-    it("updates activeId when session-list selects a conversation", async () => {
-        const el = createSidebar(
-            [
-                { id: "1", title: "First" },
-                { id: "2", title: "Second" },
-            ],
-            "1",
-        );
-        await el.updateComplete;
-
-        const list = el.shadowRoot.querySelector("session-list");
-        list.dispatchEvent(
-            new CustomEvent("select-conversation", {
-                detail: { id: "2" },
-                bubbles: true,
-                composed: true,
-            }),
-        );
-        await el.updateComplete;
-
-        expect(el.activeId).toBe("2");
-    });
-
-    // NEW: Tests for toggle functionality
+    // Toggle tests
     it("renders in expanded state by default", async () => {
         const el = createSidebar();
         await el.updateComplete;
-        expect(el.expanded).toBe(true);
+        expect(el._uiState.sidebarExpanded).toBe(true);
         const sidebar = el.shadowRoot.querySelector(".sidebar");
         expect(sidebar.classList.contains("collapsed")).toBe(false);
     });
 
     it("renders in collapsed state when expanded=false", async () => {
         const el = createSidebar();
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const sidebar = el.shadowRoot.querySelector(".sidebar");
         expect(sidebar.classList.contains("collapsed")).toBe(true);
@@ -158,7 +126,7 @@ describe("chat-sidebar", () => {
 
     it("hides content when collapsed", async () => {
         const el = createSidebar([{ id: "1", title: "Test" }]);
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const content = el.shadowRoot.querySelector(".content");
         const menuWrapper = el.shadowRoot.querySelector(".conversation-menu-wrapper");
@@ -183,19 +151,9 @@ describe("chat-sidebar", () => {
         expect(dispatched).toBe(true);
     });
 
-    it("updates expanded state on toggle", async () => {
-        const el = createSidebar();
-        await el.updateComplete;
-
-        const toggle = el.shadowRoot.querySelector("sidebar-toggle");
-        fireEvent.click(toggle.shadowRoot.querySelector("button"));
-
-        expect(el.expanded).toBe(false);
-    });
-
     it("passes collapsed prop to new-chat-button when collapsed", async () => {
         const el = createSidebar();
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const ncb = el.shadowRoot.querySelector("new-chat-button");
         expect(ncb.collapsed).toBe(true);
@@ -203,7 +161,7 @@ describe("chat-sidebar", () => {
 
     it("passes collapsed=false to new-chat-button when expanded", async () => {
         const el = createSidebar();
-        el.expanded = true;
+        el._uiState = { sidebarExpanded: true, settingsOpen: false };
         await el.updateComplete;
         const ncb = el.shadowRoot.querySelector("new-chat-button");
         expect(ncb.collapsed).toBe(false);
@@ -223,26 +181,25 @@ describe("chat-sidebar", () => {
         expect(initialButton).toBeTruthy();
 
         // Toggle to collapsed
-        el.expanded = false;
-        const updatePromise = el.updateComplete;
-        await updatePromise;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
+        await el.updateComplete;
         const collapsedButton = el.shadowRoot.querySelector("new-chat-button");
 
         // Should be the same DOM element
-        expect(collapsedButton).toBe(initialButton);
+        expect(collapsedButton === initialButton).toBeTrue();
 
         // Toggle back to expanded
-        el.expanded = true;
+        el._uiState = { sidebarExpanded: true, settingsOpen: false };
         await el.updateComplete;
         const expandedButton = el.shadowRoot.querySelector("new-chat-button");
 
         // Should still be the same DOM element
-        expect(expandedButton).toBe(initialButton);
+        expect(expandedButton === initialButton).toBeTrue();
     });
 
     it("renders conversation-menu when collapsed", async () => {
         const el = createSidebar([{ id: "1", title: "Test" }]);
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const menu = el.shadowRoot.querySelector("conversation-menu");
         const menuWrapper = el.shadowRoot.querySelector(".conversation-menu-wrapper");
@@ -252,7 +209,7 @@ describe("chat-sidebar", () => {
 
     it("renders conversation-menu when expanded (hidden via CSS)", async () => {
         const el = createSidebar([{ id: "1", title: "Test" }]);
-        el.expanded = true;
+        el._uiState = { sidebarExpanded: true, settingsOpen: false };
         await el.updateComplete;
         const menu = el.shadowRoot.querySelector("conversation-menu");
         const menuWrapper = el.shadowRoot.querySelector(".conversation-menu-wrapper");
@@ -262,7 +219,7 @@ describe("chat-sidebar", () => {
 
     it("passes collapsed prop to sidebar-profile when collapsed", async () => {
         const el = createSidebar();
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const profile = el.shadowRoot.querySelector("sidebar-profile");
         expect(profile.collapsed).toBe(true);
@@ -270,7 +227,7 @@ describe("chat-sidebar", () => {
 
     it("passes collapsed=false to sidebar-profile when expanded", async () => {
         const el = createSidebar();
-        el.expanded = true;
+        el._uiState = { sidebarExpanded: true, settingsOpen: false };
         await el.updateComplete;
         const profile = el.shadowRoot.querySelector("sidebar-profile");
         expect(profile.collapsed).toBe(false);
@@ -287,7 +244,7 @@ describe("chat-sidebar", () => {
         expect(el.shadowRoot.querySelector("conversation-menu")).toBeTruthy();
 
         // Test collapsed state
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         expect(el.shadowRoot.querySelector(".content")).toBeTruthy();
         expect(el.shadowRoot.querySelector(".conversation-menu-wrapper")).toBeTruthy();
@@ -304,7 +261,7 @@ describe("chat-sidebar", () => {
 
     it("content has correct CSS classes for collapsed state", async () => {
         const el = createSidebar([{ id: "1", title: "Test" }]);
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const content = el.shadowRoot.querySelector(".content");
         expect(content.classList.contains("collapsed")).toBe(true);
@@ -319,7 +276,7 @@ describe("chat-sidebar", () => {
 
     it("conversation-menu-wrapper has correct CSS classes for collapsed state", async () => {
         const el = createSidebar([{ id: "1", title: "Test" }]);
-        el.expanded = false;
+        el._uiState = { sidebarExpanded: false, settingsOpen: false };
         await el.updateComplete;
         const menuWrapper = el.shadowRoot.querySelector(".conversation-menu-wrapper");
         expect(menuWrapper.classList.contains("visible")).toBe(true);

--- a/client/components/chat-view.js
+++ b/client/components/chat-view.js
@@ -8,15 +8,8 @@ import { customElement } from "lit/decorators.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
-/** @typedef {import("../../shared/types.js").Message} Message */
-/** @typedef {import("../../shared/types.js").Mode} Mode */
-
 /**
  * @customElement chat-view
- * @property {Mode} mode - Current mode (gm or player).
- * @property {Message[]} messages - Messages to display in the message list.
- * @property {boolean} loading - Whether data is still loading or assistant is responding.
- * @property {boolean} responding - Whether the assistant is currently generating a response.
  * @fires mode-change - Bubbled from chat-header.
  * @fires send-message - Bubbled from chat-input.
  * @fires stop-message - Bubbled from chat-input.
@@ -35,30 +28,15 @@ class ChatView extends LitElement {
         `,
     ];
 
-    static properties = {
-        mode: { type: String },
-        messages: { type: Array },
-        loading: { type: Boolean },
-        responding: { type: Boolean },
-    };
-
     constructor() {
         super();
-        /** @type {Mode} */
-        this.mode = "player";
-        /** @type {Message[]} */
-        this.messages = [];
-        /** @type {boolean} */
-        this.loading = false;
-        /** @type {boolean} */
-        this.responding = false;
     }
 
     render() {
         return html`
-            <chat-header .mode=${this.mode}></chat-header>
-            <message-list .messages=${this.messages} .loading=${this.loading}></message-list>
-            <chat-input .mode=${this.mode} .responding=${this.responding}></chat-input>
+            <chat-header></chat-header>
+            <message-list></message-list>
+            <chat-input></chat-input>
         `;
     }
 }

--- a/client/components/chat-view.test.js
+++ b/client/components/chat-view.test.js
@@ -34,64 +34,6 @@ describe("chat-view", () => {
         expect(input).toBeTruthy();
     });
 
-    it("passes mode to chat-header", async () => {
-        element.mode = "gm";
-        await element.updateComplete;
-
-        const header = /** @type {HTMLElement & { mode: string }} */ (
-            element.shadowRoot?.querySelector("chat-header")
-        );
-        expect(header.mode).toBe("gm");
-    });
-
-    it("passes mode to chat-input", async () => {
-        element.mode = "gm";
-        await element.updateComplete;
-
-        const input = /** @type {HTMLElement & { mode: string }} */ (
-            element.shadowRoot?.querySelector("chat-input")
-        );
-        expect(input.mode).toBe("gm");
-    });
-
-    it("passes messages to message-list", async () => {
-        const msg = /** @type {import("../../shared/types.js").Message} */ ({
-            id: "m1",
-            conversationId: "c1",
-            content: "Hello",
-            role: "user",
-            mode: "player",
-            createdAt: new Date().toISOString(),
-        });
-        element.messages = [msg];
-        await element.updateComplete;
-
-        const list = /** @type {HTMLElement & { messages: unknown[] }} */ (
-            element.shadowRoot?.querySelector("message-list")
-        );
-        expect(list.messages).toEqual([msg]);
-    });
-
-    it("passes loading to message-list", async () => {
-        element.loading = true;
-        await element.updateComplete;
-
-        const list = /** @type {HTMLElement & { loading: boolean }} */ (
-            element.shadowRoot?.querySelector("message-list")
-        );
-        expect(list.loading).toBe(true);
-    });
-
-    it("passes responding to chat-input", async () => {
-        element.responding = true;
-        await element.updateComplete;
-
-        const input = /** @type {HTMLElement & { responding: boolean }} */ (
-            element.shadowRoot?.querySelector("chat-input")
-        );
-        expect(input.responding).toBe(true);
-    });
-
     it("bubbles mode-change from chat-header", async () => {
         await element.updateComplete;
 

--- a/client/components/conversation-item.js
+++ b/client/components/conversation-item.js
@@ -1,7 +1,9 @@
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { conversationContext } from "../stores/conversation-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
@@ -10,7 +12,6 @@ import { tokens } from "../styles/tokens.js";
 /**
  * @customElement conversation-item
  * @property {Conversation} conversation - The conversation to display in the item.
- * @property {boolean} active - Whether this conversation is currently active/selected.
  * @fires select - Fired when the user clicks on the conversation item, with the conversation ID in the event detail.
  */
 class ConversationItem extends LitElement {
@@ -47,20 +48,34 @@ class ConversationItem extends LitElement {
 
     static properties = {
         conversation: { type: Object },
-        active: { type: Boolean },
     };
 
     constructor() {
         super();
         /** @type {Conversation} */
         this.conversation = { id: "", title: "" };
-        /** @type {boolean} */
-        this.active = false;
+        /** @type {import("../stores/conversation-store.js").ConversationState} */
+        this._convState = { conversations: [], activeConversationId: "", loading: true };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: conversationContext,
+            callback:
+                /** @param {import("../stores/conversation-store.js").ConversationState} v */ (
+                    v,
+                ) => {
+                    this._convState = v;
+                },
+            subscribe: true,
+        });
     }
 
     render() {
+        const active = this._convState.activeConversationId === this.conversation.id;
         return html`
-            <div class="item ${this.active ? "active" : ""}" @click=${() => this.handleClick()}>
+            <div class="item ${active ? "active" : ""}" @click=${() => this.handleClick()}>
                 ${this.conversation.title}
             </div>
         `;

--- a/client/components/conversation-menu.js
+++ b/client/components/conversation-menu.js
@@ -1,21 +1,17 @@
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/menu/menu.js?deps=lit@3.3.2";
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/menu-item/menu-item.js?deps=lit@3.3.2";
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/dropdown/dropdown.js?deps=lit@3.3.2";
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { conversationContext } from "../stores/conversation-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
-/** @typedef {import("../../shared/types.js").Conversation} Conversation */
-/** @typedef {import("../../shared/types.js").Mode} Mode */
-
 /**
  * @customElement conversation-menu
- * @property {Conversation[]} conversations - The list of conversations to display in the menu.
- * @property {string} activeId - The ID of the currently active conversation.
- * @property {Mode} mode - The current mode of the application (GM or Player).
  * @fires select-conversation - Fired when the user selects a conversation from the menu, with the conversation ID in the event detail.
  */
 class ConversationMenu extends LitElement {
@@ -68,20 +64,24 @@ class ConversationMenu extends LitElement {
         `,
     ];
 
-    static properties = {
-        conversations: { type: Array },
-        activeId: { type: String },
-        mode: { type: String },
-    };
-
     constructor() {
         super();
-        /** @type {import("../../shared/types.js").Conversation[]} */
-        this.conversations = [];
-        /** @type {string} */
-        this.activeId = "";
-        /** @type {import("../../shared/types.js").Mode} */
-        this.mode = "gm";
+        /** @type {import("../stores/conversation-store.js").ConversationState} */
+        this._convState = { conversations: [], activeConversationId: "", loading: true };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: conversationContext,
+            callback:
+                /** @param {import("../stores/conversation-store.js").ConversationState} v */ (
+                    v,
+                ) => {
+                    this._convState = v;
+                },
+            subscribe: true,
+        });
     }
 
     render() {
@@ -103,13 +103,15 @@ class ConversationMenu extends LitElement {
                     >
                         Recent
                     </p>
-                    ${this.conversations
+                    ${this._convState.conversations
                         .slice(0, 5)
                         .map(
                             (conv) => html`
                                 <sl-menu-item
                                     value=${conv.id}
-                                    class=${conv.id === this.activeId ? "active" : ""}
+                                    class=${conv.id === this._convState.activeConversationId
+                                        ? "active"
+                                        : ""}
                                     @click=${() => this.handleSelect(conv.id)}
                                 >
                                     ${conv.title}

--- a/client/components/conversation-menu.test.js
+++ b/client/components/conversation-menu.test.js
@@ -15,8 +15,7 @@ describe("conversation-menu", () => {
     function createMenu(conversations = [], activeId = "") {
         /** @type {any} */
         const el = document.createElement("conversation-menu");
-        el.conversations = conversations;
-        el.activeId = activeId;
+        el._convState = { conversations, activeConversationId: activeId, loading: false };
         document.body.appendChild(el);
         return el;
     }

--- a/client/components/message-list.js
+++ b/client/components/message-list.js
@@ -1,18 +1,16 @@
 import "../components/chat-message.js";
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/spinner/spinner.js?deps=lit@3.3.2";
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html, nothing } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { messagesContext } from "../stores/messages-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
-/** @typedef {import("../../shared/types.js").Message} Message */
-
 /**
  * @customElement message-list
- * @property {Message[]} messages - The list of messages to display.
- * @property {boolean} loading - Whether the assistant is currently generating a response.
  */
 class MessageList extends LitElement {
     static styles = [
@@ -58,26 +56,30 @@ class MessageList extends LitElement {
         `,
     ];
 
-    static properties = {
-        messages: { type: Array },
-        loading: { type: Boolean },
-    };
-
     constructor() {
         super();
-        /** @type {Message[]} */
-        this.messages = [];
-        /** @type {boolean} */
-        this.loading = false;
+        /** @type {import("../stores/messages-store.js").MessagesState} */
+        this._msgState = { messages: [], responding: false };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: messagesContext,
+            callback: /** @param {import("../stores/messages-store.js").MessagesState} v */ (v) => {
+                this._msgState = v;
+            },
+            subscribe: true,
+        });
     }
 
     render() {
         return html`
             <div class="messages">
-                ${this.messages
+                ${this._msgState.messages
                     .toReversed()
                     .map((msg) => html` <chat-message .message=${msg}></chat-message> `)}
-                ${this.loading
+                ${this._msgState.responding
                     ? html`
                           <div class="loading">
                               <sl-spinner style="font-size: 1rem;"></sl-spinner>

--- a/client/components/message-list.test.js
+++ b/client/components/message-list.test.js
@@ -13,7 +13,7 @@ describe("message-list", () => {
         /** @type {any} */
         const el = document.createElement("message-list");
         if (messages !== undefined) {
-            el.messages = messages;
+            el._msgState = { messages, responding: false };
         }
         document.body.appendChild(el);
         return el;
@@ -43,17 +43,17 @@ describe("message-list", () => {
         expect(msgs.length).toBe(2);
     });
 
-    it("shows loading spinner when loading is true", async () => {
+    it("shows loading spinner when responding is true", async () => {
         const el = createList([]);
-        el.loading = true;
+        el._msgState = { messages: [], responding: true };
         await el.updateComplete;
         expect(el.shadowRoot.querySelector(".loading")).toBeTruthy();
         expect(el.shadowRoot.querySelector("sl-spinner")).toBeTruthy();
     });
 
-    it("hides loading spinner when loading is false", async () => {
+    it("hides loading spinner when responding is false", async () => {
         const el = createList([]);
-        el.loading = false;
+        el._msgState = { messages: [], responding: false };
         await el.updateComplete;
         expect(el.shadowRoot.querySelector(".loading")).toBeNull();
     });

--- a/client/components/mode-toggle.js
+++ b/client/components/mode-toggle.js
@@ -1,15 +1,16 @@
 /** @typedef {import("../../shared/types.js").Mode} Mode */
 
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { modeContext } from "../stores/mode-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
 /**
  * @customElement mode-toggle
- * @property {Mode} mode - The current mode of the application (GM or Player).
  * @fires mode-change - Fired when the user changes the mode using the mode toggle.
  */
 class ModeToggle extends LitElement {
@@ -53,14 +54,21 @@ class ModeToggle extends LitElement {
         `,
     ];
 
-    static properties = {
-        mode: { type: String },
-    };
-
     constructor() {
         super();
-        /** @type {Mode} */
-        this.mode = "player";
+        /** @type {import("../stores/mode-store.js").ModeState} */
+        this._modeState = { mode: "player" };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: modeContext,
+            callback: /** @param {import("../stores/mode-store.js").ModeState} v */ (v) => {
+                this._modeState = v;
+            },
+            subscribe: true,
+        });
     }
 
     render() {
@@ -68,13 +76,13 @@ class ModeToggle extends LitElement {
             <div class="mode-toggle">
                 <button
                     @click=${() => this.setMode("player")}
-                    class="mode-btn ${this.mode === "player" ? "active" : "inactive"}"
+                    class="mode-btn ${this._modeState.mode === "player" ? "active" : "inactive"}"
                 >
                     ⚔️ Player Mode
                 </button>
                 <button
                     @click=${() => this.setMode("gm")}
-                    class="mode-btn ${this.mode === "gm" ? "active" : "inactive"}"
+                    class="mode-btn ${this._modeState.mode === "gm" ? "active" : "inactive"}"
                 >
                     📜 GM Mode
                 </button>
@@ -86,7 +94,6 @@ class ModeToggle extends LitElement {
      * @param {Mode} mode
      */
     setMode(mode) {
-        this.mode = mode;
         this.dispatchEvent(
             new CustomEvent("mode-change", { detail: { mode }, bubbles: true, composed: true }),
         );

--- a/client/components/mode-toggle.test.js
+++ b/client/components/mode-toggle.test.js
@@ -12,8 +12,9 @@ describe("mode-toggle", () => {
     function createToggle(mode = "player") {
         /** @type {any} */
         const el = document.createElement("mode-toggle");
-        el.mode = mode;
         document.body.appendChild(el);
+        // ContextConsumer may have run with default, set internal state directly
+        el._modeState = { mode };
         return el;
     }
 

--- a/client/components/profile-menu.js
+++ b/client/components/profile-menu.js
@@ -10,8 +10,6 @@ import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/menu/menu
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/menu-item/menu-item.js?deps=lit@3.3.2";
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/divider/divider.js?deps=lit@3.3.2";
 
-/** @typedef {import("../../shared/types.js").Mode} Mode */
-
 class ProfileMenu extends LitElement {
     static styles = [
         tokens,
@@ -55,14 +53,8 @@ class ProfileMenu extends LitElement {
         `,
     ];
 
-    static properties = {
-        mode: { type: String },
-    };
-
     constructor() {
         super();
-        /** @type {Mode} */
-        this.mode = "gm";
     }
 
     render() {

--- a/client/components/session-list.js
+++ b/client/components/session-list.js
@@ -1,9 +1,11 @@
 import "https://esm.sh/@shoelace-style/shoelace@2.20.1/dist/components/input/input.js?deps=lit@3.3.2";
 import "./conversation-item.js";
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { conversationContext } from "../stores/conversation-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 
@@ -16,8 +18,6 @@ import { tokens } from "../styles/tokens.js";
 
 /**
  * @customElement session-list
- * @property {Conversation[]} conversations - The list of conversations to display in the list.
- * @property {string} activeId - The ID of the currently active conversation.
  * @property {string} query - The current search query for filtering conversations.
  * @fires select-conversation - Fired when the user selects a conversation from the list, with the conversation ID in the event detail.
  */
@@ -56,27 +56,37 @@ class SessionList extends LitElement {
     ];
 
     static properties = {
-        conversations: { type: Array },
-        activeId: { type: String },
         query: { type: String },
     };
 
     constructor() {
         super();
-        /** @type {Conversation[]} */
-        this.conversations = [];
-        /** @type {string} */
-        this.activeId = "";
         /** @type {string} */
         this.query = "";
+        /** @type {import("../stores/conversation-store.js").ConversationState} */
+        this._convState = { conversations: [], activeConversationId: "", loading: true };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: conversationContext,
+            callback:
+                /** @param {import("../stores/conversation-store.js").ConversationState} v */ (
+                    v,
+                ) => {
+                    this._convState = v;
+                },
+            subscribe: true,
+        });
     }
 
     render() {
         const filtered = this.query
-            ? this.conversations.filter((c) =>
+            ? this._convState.conversations.filter((c) =>
                   c.title.toLowerCase().includes(this.query.toLowerCase()),
               )
-            : this.conversations;
+            : this._convState.conversations;
 
         return html`
             <div class="container">
@@ -93,7 +103,6 @@ class SessionList extends LitElement {
                     (conv) => html`
                         <conversation-item
                             .conversation=${conv}
-                            .active=${conv.id === this.activeId}
                             @select=${this.handleSelect}
                             data-test="session-item"
                         ></conversation-item>

--- a/client/components/session-list.test.js
+++ b/client/components/session-list.test.js
@@ -12,8 +12,7 @@ describe("session-list", () => {
     function createList(conversations = [], activeId = "") {
         /** @type {any} */
         const el = document.createElement("session-list");
-        el.conversations = conversations;
-        el.activeId = activeId;
+        el._convState = { conversations, activeConversationId: activeId, loading: false };
         document.body.appendChild(el);
         return el;
     }
@@ -47,8 +46,17 @@ describe("session-list", () => {
     it("highlights active conversation", async () => {
         const el = createList([{ id: "1", title: "Active Chat" }], "1");
         await el.updateComplete;
-        const item = el.shadowRoot.querySelector("conversation-item");
-        expect(item?.active).toBe(true);
+        const item = /** @type {any} */ (el.shadowRoot.querySelector("conversation-item"));
+        // conversation-item consumes from context; set its internal state directly
+        if (item) {
+            item._convState = {
+                conversations: [{ id: "1", title: "Active Chat" }],
+                activeConversationId: "1",
+                loading: false,
+            };
+            item.requestUpdate();
+            await item.updateComplete;
+        }
         const itemDiv = item?.shadowRoot?.querySelector(".item");
         expect(itemDiv?.classList.contains("active")).toBe(true);
     });
@@ -63,6 +71,19 @@ describe("session-list", () => {
         );
         await el.updateComplete;
         const items = el.shadowRoot.querySelectorAll("conversation-item");
+        // Set context state on each conversation-item child
+        for (const item of items) {
+            /** @type {any} */ (item)._convState = {
+                conversations: [
+                    { id: "1", title: "Active" },
+                    { id: "2", title: "Inactive" },
+                ],
+                activeConversationId: "1",
+                loading: false,
+            };
+            /** @type {any} */ (item).requestUpdate();
+        }
+        await Promise.all(Array.from(items).map((i) => /** @type {any} */ (i).updateComplete));
         const inactiveItem = Array.from(items).find((item) =>
             item.shadowRoot?.querySelector(".item")?.textContent?.includes("Inactive"),
         );
@@ -136,7 +157,7 @@ describe("session-list", () => {
         );
     });
 
-    it("shows all conversations when query is cleared", async () => {
+    it("shows all conversations when query is cleared (second test)", async () => {
         const el = createList([
             { id: "1", title: "Mitflit King" },
             { id: "2", title: "Chandelier Plot" },

--- a/client/components/settings-dialog.js
+++ b/client/components/settings-dialog.js
@@ -107,6 +107,7 @@ class SettingsDialog extends LitElement {
     static properties = {
         user: { type: Object },
         devices: { type: Array },
+        _uiState: { type: Object },
         nameInput: { type: String },
         modeInput: { type: String },
         loading: { type: Boolean },
@@ -169,7 +170,7 @@ class SettingsDialog extends LitElement {
             changedProperties.get("_uiState")
         );
         const wasOpen = prevUIState?.settingsOpen;
-        if (this._uiState.settingsOpen && !wasOpen && !this.devices.length) {
+        if (this._uiState.settingsOpen && !wasOpen && !(this.devices || []).length) {
             void this.fetchDevices();
         }
     }
@@ -241,7 +242,7 @@ class SettingsDialog extends LitElement {
                 <div class="section">
                     <h3 class="section-title">Passkeys</h3>
                     <div class="devices-list">
-                        ${this.devices.map(
+                        ${(this.devices || []).map(
                             (device) => html`
                                 <div class="device-item">
                                     <div class="device-info">
@@ -252,7 +253,7 @@ class SettingsDialog extends LitElement {
                                             >${this.formatDate(device.createdAt)}</span
                                         >
                                     </div>
-                                    ${this.devices.length > 1
+                                    ${(this.devices || []).length > 1
                                         ? html`
                                               <sl-button
                                                   size="small"
@@ -369,7 +370,7 @@ class SettingsDialog extends LitElement {
         try {
             const res = await client.api.auth.devices.$get();
             const data = await res.json();
-            this.devices = data.data;
+            this.devices = data.data ?? [];
         } catch {
             // Failed to fetch devices
         } finally {

--- a/client/components/settings-dialog.js
+++ b/client/components/settings-dialog.js
@@ -1,8 +1,10 @@
+import { ContextConsumer } from "@lit/context";
 import { startRegistration } from "@simplewebauthn/browser";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { uiContext } from "../stores/ui-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 import { client } from "../utils/rpc-client.js";
@@ -103,7 +105,6 @@ class SettingsDialog extends LitElement {
     ];
 
     static properties = {
-        open: { type: Boolean },
         user: { type: Object },
         devices: { type: Array },
         nameInput: { type: String },
@@ -114,8 +115,6 @@ class SettingsDialog extends LitElement {
 
     constructor() {
         super();
-        /** @type {boolean} */
-        this.open = false;
         /** @type {AuthUser | null} */
         this.user = null;
         /** @type {import("zod").z.infer<typeof import("../../server/db/queries.js").DeviceListSchema>} */
@@ -128,6 +127,19 @@ class SettingsDialog extends LitElement {
         this.loading = false;
         /** @type {string} */
         this.error = "";
+        /** @type {import("../stores/ui-store.js").UIState} */
+        this._uiState = { sidebarExpanded: true, settingsOpen: false };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: uiContext,
+            callback: /** @param {import("../stores/ui-store.js").UIState} v */ (v) => {
+                this._uiState = v;
+            },
+            subscribe: true,
+        });
     }
 
     /** @param {Map<string, unknown>} changedProperties */
@@ -140,11 +152,11 @@ class SettingsDialog extends LitElement {
             this.modeInput = this.user.mode;
         }
 
-        // Sync dialog open state
-        if (changedProperties.has("open")) {
+        // Sync dialog open state from context
+        if (changedProperties.has("_uiState") || this._uiStateChanged(changedProperties)) {
             const dialog = /** @type {ShadowRoot} */ (this.shadowRoot).querySelector("sl-dialog");
             if (dialog) {
-                if (this.open) {
+                if (this._uiState.settingsOpen) {
                     void dialog.show();
                 } else {
                     void dialog.hide();
@@ -153,9 +165,27 @@ class SettingsDialog extends LitElement {
         }
 
         // Fetch devices when dialog opens
-        if (changedProperties.has("open") && this.open && !this.devices.length) {
+        const prevUIState = /** @type {{ settingsOpen: boolean } | undefined} */ (
+            changedProperties.get("_uiState")
+        );
+        const wasOpen = prevUIState?.settingsOpen;
+        if (this._uiState.settingsOpen && !wasOpen && !this.devices.length) {
             void this.fetchDevices();
         }
+    }
+
+    /**
+     * @param {Map<string, unknown>} changedProperties
+     * @returns {boolean}
+     */
+    _uiStateChanged(changedProperties) {
+        if (!changedProperties.has("_uiState")) {
+            return false;
+        }
+        const prev = /** @type {{ settingsOpen: boolean } | undefined} */ (
+            changedProperties.get("_uiState")
+        );
+        return prev ? prev.settingsOpen !== this._uiState.settingsOpen : true;
     }
 
     render() {
@@ -313,7 +343,7 @@ class SettingsDialog extends LitElement {
                     composed: true,
                 }),
             );
-            this.open = false;
+            this._hideDialog();
         } catch (err) {
             this.error = Error.isError(err) ? err.message : "Failed to save settings";
         } finally {
@@ -322,7 +352,17 @@ class SettingsDialog extends LitElement {
     }
 
     handleClose() {
-        this.open = false;
+        this._hideDialog();
+    }
+
+    /**
+     * Hides the Shoelace dialog element directly.
+     */
+    _hideDialog() {
+        const dialog = /** @type {ShadowRoot} */ (this.shadowRoot)?.querySelector("sl-dialog");
+        if (dialog) {
+            void dialog.hide();
+        }
     }
 
     async fetchDevices() {
@@ -432,7 +472,7 @@ class SettingsDialog extends LitElement {
                     composed: true,
                 }),
             );
-            this.open = false;
+            this._hideDialog();
         } catch (err) {
             this.error = Error.isError(err) ? err.message : "Failed to delete account";
         } finally {

--- a/client/components/settings-dialog.test.js
+++ b/client/components/settings-dialog.test.js
@@ -11,7 +11,7 @@ describe("settings-dialog", () => {
     function createDialog() {
         /** @type {any} */
         const el = document.createElement("settings-dialog");
-        el.open = true;
+        el._uiState = { sidebarExpanded: true, settingsOpen: true };
         return el;
     }
 
@@ -20,7 +20,7 @@ describe("settings-dialog", () => {
         document.body.appendChild(container);
     });
 
-    test("renders when open is true", async () => {
+    test("renders when settingsOpen is true", async () => {
         const mockUser = {
             id: "test-id",
             name: "Test User",

--- a/client/components/sidebar-profile.js
+++ b/client/components/sidebar-profile.js
@@ -1,12 +1,13 @@
+import { ContextConsumer } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { modeContext } from "../stores/mode-store.js";
 import { baseStyles } from "../styles/base-styles.js";
-import { tokens } from "../styles/tokens.js";
 import "./profile-menu.js";
+import { tokens } from "../styles/tokens.js";
 
-/** @typedef {import("../../shared/types.js").Mode} Mode */
 /** @typedef {import("../../shared/types.js").AuthUser} AuthUser */
 
 /**
@@ -14,7 +15,6 @@ import "./profile-menu.js";
  * @property {string} name - The name of the user to display in the profile section.
  * @property {string} subtitle - The subtitle or role of the user.
  * @property {string} initials - The initials of the user to display in the avatar.
- * @property {Mode} mode - The current mode of the application (GM or Player).
  * @property {boolean} collapsed - Whether the sidebar is currently collapsed, which affects the profile's appearance.
  */
 class SidebarProfile extends LitElement {
@@ -89,7 +89,6 @@ class SidebarProfile extends LitElement {
         name: { type: String },
         subtitle: { type: String },
         initials: { type: String },
-        mode: { type: String },
         collapsed: { type: Boolean },
         user: { type: Object },
     };
@@ -102,12 +101,23 @@ class SidebarProfile extends LitElement {
         this.subtitle = "";
         /** @type {string} */
         this.initials = "";
-        /** @type {Mode} */
-        this.mode = "gm";
         /** @type {boolean} */
         this.collapsed = false;
         /** @type {AuthUser | null} */
         this.user = null;
+        /** @type {import("../stores/mode-store.js").ModeState} */
+        this._modeState = { mode: "gm" };
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        new ContextConsumer(this, {
+            context: modeContext,
+            callback: /** @param {import("../stores/mode-store.js").ModeState} v */ (v) => {
+                this._modeState = v;
+            },
+            subscribe: true,
+        });
     }
 
     /**
@@ -129,7 +139,6 @@ class SidebarProfile extends LitElement {
                 aria-label=${this.collapsed ? `${this.name} - ${this.subtitle}` : ""}
             >
                 <profile-menu
-                    .mode=${this.mode}
                     @logout=${this.handleLogout}
                     @open-settings=${this.handleOpenSettings}
                 ></profile-menu>

--- a/client/index.html
+++ b/client/index.html
@@ -13,6 +13,7 @@
             {
                 "imports": {
                     "@simplewebauthn/browser": "https://esm.sh/@simplewebauthn/browser@13.3.0",
+                    "@lit/context": "https://esm.sh/@lit/context@1.1.2",
                     "lit/decorators.js": "https://esm.sh/lit@3.3.2/decorators.js",
                     "lit-html": "https://esm.sh/lit-html@3.3.2",
                     "lit-element": "https://esm.sh/lit-element@4.2.2",

--- a/client/pages/main-page.js
+++ b/client/pages/main-page.js
@@ -2,10 +2,15 @@ import "../components/chat-sidebar.js";
 import "../components/chat-view.js";
 import "../components/landing-view.js";
 import "../components/settings-dialog.js";
+import { ContextProvider } from "@lit/context";
 import { LitElement, css } from "lit-element";
 import { html } from "lit-html";
 import { customElement } from "lit/decorators.js";
 
+import { conversationContext, createConversationStore } from "../stores/conversation-store.js";
+import { messagesContext, createMessagesStore } from "../stores/messages-store.js";
+import { modeContext, createModeStore } from "../stores/mode-store.js";
+import { uiContext, createUIStore } from "../stores/ui-store.js";
 import { baseStyles } from "../styles/base-styles.js";
 import { tokens } from "../styles/tokens.js";
 import { logout } from "../utils/auth-client.js";
@@ -53,92 +58,167 @@ class MainPage extends LitElement {
     ];
 
     static properties = {
-        conversations: { type: Array },
-        activeConversationId: { type: String },
-        messages: { type: Array },
-        mode: { type: String },
-        loading: { type: Boolean },
-        responding: { type: Boolean },
-        sidebarExpanded: { type: Boolean },
         user: { type: Object },
-        settingsOpen: { type: Boolean },
         _landingSubmitting: { type: Boolean },
+        _convState: { type: Object },
+        _msgState: { type: Object },
+        _modeState: { type: Object },
+        _uiState: { type: Object },
     };
 
     constructor() {
         super();
-        /** @type {Conversation[]} */
-        this.conversations = [];
-        /** @type {string} */
-        this.activeConversationId = "";
-        /** @type {import("../../shared/types.js").Message[]} */
-        this.messages = [];
-        /** @type {Mode} */
-        this.mode = "player";
-        /** @type {boolean} */
-        this.loading = true;
-        /** @type {boolean} */
-        this.responding = false;
-        /** @type {AbortController | null} */
-        this._currentAssistantController = null;
-        this.sidebarExpanded = true;
         /** @type {AuthUser | null} */
         this.user = null;
         /** @type {boolean} */
-        this.settingsOpen = false;
-        /** @type {boolean} */
         this._landingSubmitting = false;
+
+        // Internal state objects (provided via ContextProvider)
+        /** @type {import("../stores/conversation-store.js").ConversationState} */
+        this._convState = { conversations: [], activeConversationId: "", loading: true };
+
+        /** @type {import("../stores/messages-store.js").MessagesState} */
+        this._msgState = { messages: [], responding: false };
+
+        /** @type {import("../stores/mode-store.js").ModeState} */
+        this._modeState = { mode: "player" };
+
+        /** @type {import("../stores/ui-store.js").UIState} */
+        this._uiState = { sidebarExpanded: true, settingsOpen: false };
+
+        // Store instances
+        this._convStore = createConversationStore();
+        this._msgStore = createMessagesStore();
+        this._modeStore = createModeStore();
+        this._uiStore = createUIStore();
+
+        /** @type {AbortController | null} */
+        this._currentAssistantController = null;
     }
 
     get isLanding() {
-        return !this.loading && this.filteredMessages.length === 0;
+        return !this._convState.loading && this._msgState.messages.length === 0;
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        // ContextProvider instances with guards against re-creation
+        if (!this._convProvider) {
+            this._convProvider = new ContextProvider(this, {
+                context: conversationContext,
+                initialValue: this._convState,
+            });
+        }
+        if (!this._msgProvider) {
+            this._msgProvider = new ContextProvider(this, {
+                context: messagesContext,
+                initialValue: this._msgState,
+            });
+        }
+        if (!this._modeProvider) {
+            this._modeProvider = new ContextProvider(this, {
+                context: modeContext,
+                initialValue: this._modeState,
+            });
+        }
+        if (!this._uiProvider) {
+            this._uiProvider = new ContextProvider(this, {
+                context: uiContext,
+                initialValue: this._uiState,
+            });
+        }
+    }
+
+    /**
+     * @param {import("../stores/conversation-store.js").ConversationState} state
+     */
+    _updateConvState(state) {
+        this._convState = state;
+        if (this._convProvider) {
+            this._convProvider.setValue(state);
+        }
+    }
+
+    /**
+     * @param {import("../stores/messages-store.js").MessagesState} state
+     */
+    _updateMsgState(state) {
+        this._msgState = state;
+        if (this._msgProvider) {
+            this._msgProvider.setValue(state);
+        }
+    }
+
+    /**
+     * @param {import("../stores/mode-store.js").ModeState} state
+     */
+    _updateModeState(state) {
+        this._modeState = state;
+        if (this._modeProvider) {
+            this._modeProvider.setValue(state);
+        }
+    }
+
+    /**
+     * @param {import("../stores/ui-store.js").UIState} state
+     */
+    _updateUIState(state) {
+        this._uiState = state;
+        if (this._uiProvider) {
+            this._uiProvider.setValue(state);
+        }
     }
 
     async firstUpdated() {
         try {
             // Set mode from user
             if (this.user) {
-                this.mode = this.user.mode;
+                const newMode = this.user.mode;
+                this._updateModeState({ mode: newMode });
             }
 
-            // Step 1: Fetch conversations list
-            const convRes = await client.api.conversations.$get();
-            const convResult = await convRes.json();
-            this.conversations = convResult.data;
+            // Fetch conversations
+            const conversations = await this._convStore.fetchConversations();
+            let activeId = "";
 
-            // Step 2: Set active conversation from result (first conversation)
-            if (this.conversations.length > 0) {
-                this.activeConversationId = this.conversations[0].id;
-
-                // Step 3: Fetch messages for the active conversation
-                const msgRes = await client.api.conversations[":id"].messages.$get({
-                    param: { id: this.activeConversationId },
-                });
-                const msgResult = await msgRes.json();
-                this.messages = /** @type {import("../../shared/types.js").Message[]} */ (
-                    msgResult.data
-                );
+            // Set active conversation from result (first conversation)
+            if (conversations.length > 0) {
+                activeId = conversations[0].id;
             }
-        } finally {
-            this.loading = false;
+
+            this._updateConvState({ conversations, activeConversationId: activeId, loading: true });
+
+            // Fetch messages for the active conversation
+            if (activeId) {
+                const messages = await this._msgStore.fetchMessages(activeId);
+                this._updateMsgState({ messages, responding: false });
+            }
+
+            this._updateConvState({
+                conversations,
+                activeConversationId: activeId,
+                loading: false,
+            });
+        } catch {
+            this._updateConvState({
+                ...this._convState,
+                loading: false,
+            });
         }
     }
 
     render() {
         return html`
-            <div class="app" data-mode=${this.mode}>
+            <div class="app" data-mode=${this._modeState.mode}>
                 <chat-sidebar
-                    .conversations=${this.conversations}
-                    .activeId=${this.activeConversationId}
-                    .mode=${this.mode}
-                    .expanded=${this.sidebarExpanded}
                     .user=${this.user}
                     @new-chat=${this.handleNewChat}
                     @select-conversation=${this.handleSelectConversation}
                     @toggle-sidebar=${this.handleSidebarToggle}
                     @logout=${this.handleLogout}
                     @open-settings=${() => {
-                        this.settingsOpen = true;
+                        this._updateUIState(this._uiStore.openSettings(this._uiState));
                     }}
                 ></chat-sidebar>
                 <main class="main">
@@ -151,10 +231,6 @@ class MainPage extends LitElement {
                           `
                         : html`
                               <chat-view
-                                  .mode=${this.mode}
-                                  .messages=${this.filteredMessages}
-                                  .loading=${this.loading || this.responding}
-                                  .responding=${this.responding}
                                   @mode-change=${this.handleModeChange}
                                   @send-message=${this.handleSendMessage}
                                   @stop-message=${this.handleStopMessage}
@@ -163,10 +239,9 @@ class MainPage extends LitElement {
                 </main>
             </div>
             <settings-dialog
-                .open=${this.settingsOpen}
                 .user=${this.user}
                 @settings-closed=${() => {
-                    this.settingsOpen = false;
+                    this._updateUIState(this._uiStore.closeSettings(this._uiState));
                 }}
                 @settings-updated=${this.handleSettingsUpdated}
                 @account-deleted=${this.handleAccountDeleted}
@@ -174,61 +249,51 @@ class MainPage extends LitElement {
         `;
     }
 
-    async fetchConversations() {
-        const res = await client.api.conversations.$get();
-        const result = await res.json();
-        this.conversations = result.data;
-    }
-
-    /**
-     * @param {string} convId the conversation id
-     */
-    async fetchMessages(convId) {
-        const res = await client.api.conversations[":id"].messages.$get({
-            param: { id: convId },
-        });
-        const result = await res.json();
-        this.messages = /** @type {import("../../shared/types.js").Message[]} */ (result.data);
-    }
-
     async handleNewChat() {
-        const res = await client.api.conversations.$post({
-            json: { title: "New Conversation" },
+        const conv = await this._convStore.createConversation("New Conversation");
+        const newConversations = [...this._convState.conversations, conv];
+        this._updateConvState({
+            conversations: newConversations,
+            activeConversationId: conv.id,
+            loading: false,
         });
-        const conv = await res.json();
-        this.conversations = [...this.conversations, conv.data];
-        this.activeConversationId = conv.data.id;
-        await this.fetchMessages(conv.data.id);
+        await this.handleSelectConversation(
+            new CustomEvent("select-conversation", { detail: { id: conv.id } }),
+        );
     }
 
     /**
      * @param {CustomEvent<{ id: string }>} e
      */
     async handleSelectConversation(e) {
-        this.activeConversationId = e.detail.id;
-        await this.fetchMessages(e.detail.id);
+        const convId = e.detail.id;
+        this._updateConvState({ ...this._convState, activeConversationId: convId });
+        const msgs = await this._msgStore.fetchMessages(convId);
+        this._updateMsgState({ messages: msgs, responding: false });
     }
 
     /**
      * @param {CustomEvent<{ mode: Mode }>} e
      */
     handleModeChange(e) {
-        this.mode = e.detail.mode;
+        const newState = this._modeStore.setMode(e.detail.mode);
+        this._updateModeState(newState);
     }
 
     /**
      * @param {CustomEvent<{ text: string }>} e
      */
     async handleSendMessage(e) {
-        this.responding = true;
+        const newResponding = { messages: this._msgState.messages, responding: true };
+        this._updateMsgState(newResponding);
         const controller = new AbortController();
         this._currentAssistantController = controller;
 
         try {
             const res = await client.api.conversations[":id"].messages.$post(
                 {
-                    param: { id: this.activeConversationId },
-                    json: { content: e.detail.text, mode: this.mode },
+                    param: { id: this._convState.activeConversationId },
+                    json: { content: e.detail.text, mode: this._modeState.mode },
                 },
                 {
                     init: { signal: controller.signal },
@@ -240,80 +305,52 @@ class MainPage extends LitElement {
             if (!body) {
                 throw new Error("No response body");
             }
-            const reader = body.getReader();
-            const decoder = new TextDecoder();
+
             /** @type {import("../../shared/types.js").Message | null} */
             let userMessage = null;
             /** @type {import("../../shared/types.js").AssistantMessage | null} */
             let assistantMessage = null;
             let assistantMessageAdded = false;
+            let messages = this._msgState.messages;
 
-            while (true) {
-                const result = await reader.read();
-                if (result.done) {
-                    break;
-                }
-                const value = result.value;
-                const chunk = decoder.decode(value, { stream: true });
-                const lines = chunk.split("\n").filter(Boolean);
-                for (const line of lines) {
-                    /** @type {unknown} */
-                    const data = JSON.parse(line);
-                    if (
-                        typeof data === "object" &&
-                        data !== null &&
-                        "type" in data &&
-                        typeof data.type === "string" &&
-                        "data" in data
-                    ) {
-                        /** @type {{ type: string, data: unknown }} */
-                        const typedData = /** @type {{ type: string, data: unknown }} */ (data);
-                        if (typedData.type === "userMessage") {
-                            userMessage = /** @type {import("../../shared/types.js").Message} */ (
-                                typedData.data
-                            );
-                            this.messages = [...this.messages, userMessage];
-                        } else if (typedData.type === "assistantChunk") {
-                            if (!assistantMessage) {
-                                assistantMessage = {
-                                    id: "temp-assistant-" + Date.now(),
-                                    role: "assistant",
-                                    blocks: [],
-                                    mode: this.mode,
-                                    conversationId: this.activeConversationId,
-                                    content: null,
-                                    createdAt: new Date().toISOString(),
-                                };
-                            }
-                            assistantMessage = {
-                                ...assistantMessage,
-                                blocks: [
-                                    ...(assistantMessage?.blocks ?? []),
-                                    /** @type {import("../../shared/types.js").MessageBlock} */ (
-                                        typedData.data
-                                    ),
-                                ],
-                            };
-
-                            if (!assistantMessageAdded) {
-                                this.messages = [...this.messages, assistantMessage];
-                                assistantMessageAdded = true;
-                            } else {
-                                this.messages = [...this.messages.slice(0, -1), assistantMessage];
-                            }
-                        } else if (typedData.type === "assistantComplete") {
-                            assistantMessage =
-                                /** @type {import("../../shared/types.js").AssistantMessage} */ (
-                                    typedData.data
-                                );
-                            if (!assistantMessageAdded) {
-                                this.messages = [...this.messages, assistantMessage];
-                                assistantMessageAdded = true;
-                            } else {
-                                this.messages = [...this.messages.slice(0, -1), assistantMessage];
-                            }
-                        }
+            for await (const event of this._msgStore.parseSSEStream(body)) {
+                if (event.type === "userMessage") {
+                    userMessage = event.data;
+                    messages = [...messages, userMessage];
+                    this._updateMsgState({ messages, responding: true });
+                } else if (event.type === "assistantChunk") {
+                    if (!assistantMessage) {
+                        assistantMessage = {
+                            id: "temp-assistant-" + Date.now(),
+                            role: "assistant",
+                            blocks: [],
+                            mode: this._modeState.mode,
+                            conversationId: this._convState.activeConversationId,
+                            content: null,
+                            createdAt: new Date().toISOString(),
+                        };
                     }
+                    assistantMessage = {
+                        ...assistantMessage,
+                        blocks: [...(assistantMessage?.blocks ?? []), event.data],
+                    };
+
+                    if (!assistantMessageAdded) {
+                        messages = [...messages, assistantMessage];
+                        assistantMessageAdded = true;
+                    } else {
+                        messages = [...messages.slice(0, -1), assistantMessage];
+                    }
+                    this._updateMsgState({ messages, responding: true });
+                } else if (event.type === "assistantComplete") {
+                    assistantMessage = event.data;
+                    if (!assistantMessageAdded) {
+                        messages = [...messages, assistantMessage];
+                        assistantMessageAdded = true;
+                    } else {
+                        messages = [...messages.slice(0, -1), assistantMessage];
+                    }
+                    this._updateMsgState({ messages, responding: true });
                 }
             }
         } catch (err) {
@@ -321,7 +358,7 @@ class MainPage extends LitElement {
                 // Ignore error
             }
         } finally {
-            this.responding = false;
+            this._updateMsgState({ messages: this._msgState.messages, responding: false });
             this._currentAssistantController = null;
         }
     }
@@ -330,15 +367,11 @@ class MainPage extends LitElement {
         this._currentAssistantController?.abort();
     }
 
-    get filteredMessages() {
-        return this.messages.filter(
-            (message) => message.conversationId === this.activeConversationId,
-        );
-    }
-
-    /** @param {CustomEvent<{ expanded: boolean }>} e */
+    /**
+     * @param {CustomEvent<{ expanded: boolean }>} e
+     */
     handleSidebarToggle(e) {
-        this.sidebarExpanded = e.detail.expanded;
+        this._updateUIState({ ...this._uiState, sidebarExpanded: e.detail.expanded });
     }
 
     async handleLogout() {
@@ -356,7 +389,7 @@ class MainPage extends LitElement {
      */
     handleSettingsUpdated(e) {
         this.user = e.detail.user;
-        this.mode = this.user.mode;
+        this._updateModeState({ mode: this.user.mode });
     }
 
     async handleAccountDeleted() {
@@ -377,23 +410,24 @@ class MainPage extends LitElement {
         this._landingSubmitting = true;
 
         /** @type {string} */
-        let targetConvId = this.activeConversationId;
+        let targetConvId = this._convState.activeConversationId;
 
         try {
-            if (this.conversations.length === 0) {
-                const res = await client.api.conversations.$post({
-                    json: { title: text.slice(0, 80) },
+            if (this._convState.conversations.length === 0) {
+                const conv = await this._convStore.createConversation(text.slice(0, 80));
+                const newConversations = [conv, ...this._convState.conversations];
+                targetConvId = conv.id;
+                this._updateConvState({
+                    conversations: newConversations,
+                    activeConversationId: conv.id,
+                    loading: false,
                 });
-                const conv = await res.json();
-                const convData = conv.data;
-
-                this.conversations = [convData, ...this.conversations];
-                this.activeConversationId = convData.id;
-                targetConvId = convData.id;
-                await this.fetchMessages(convData.id);
+                const msgs = await this._msgStore.fetchMessages(conv.id);
+                this._updateMsgState({ messages: msgs, responding: false });
             }
 
-            this.responding = true;
+            const newResponding = { messages: this._msgState.messages, responding: true };
+            this._updateMsgState(newResponding);
             const controller = new AbortController();
             this._currentAssistantController = controller;
 
@@ -401,7 +435,7 @@ class MainPage extends LitElement {
                 const msgRes = await client.api.conversations[":id"].messages.$post(
                     {
                         param: { id: targetConvId },
-                        json: { content: text, mode: this.mode },
+                        json: { content: text, mode: this._modeState.mode },
                     },
                     {
                         init: { signal: controller.signal },
@@ -413,87 +447,52 @@ class MainPage extends LitElement {
                 if (!body) {
                     throw new Error("No response body");
                 }
-                const reader = body.getReader();
-                const decoder = new TextDecoder();
+
                 /** @type {import("../../shared/types.js").Message | null} */
                 let userMessage = null;
                 /** @type {import("../../shared/types.js").AssistantMessage | null} */
                 let assistantMessage = null;
                 let assistantMessageAdded = false;
+                let messages = this._msgState.messages;
 
-                while (true) {
-                    const result = await reader.read();
-                    if (result.done) {
-                        break;
-                    }
-                    const value = result.value;
-                    const chunk = decoder.decode(value, { stream: true });
-                    const lines = chunk.split("\n").filter(Boolean);
-                    for (const line of lines) {
-                        /** @type {unknown} */
-                        const data = JSON.parse(line);
-                        if (
-                            typeof data === "object" &&
-                            data !== null &&
-                            "type" in data &&
-                            typeof data.type === "string" &&
-                            "data" in data
-                        ) {
-                            /** @type {{ type: string, data: unknown }} */
-                            const typedData = /** @type {{ type: string, data: unknown }} */ (data);
-                            if (typedData.type === "userMessage") {
-                                userMessage =
-                                    /** @type {import("../../shared/types.js").Message} */ (
-                                        typedData.data
-                                    );
-                                this.messages = [...this.messages, userMessage];
-                            } else if (typedData.type === "assistantChunk") {
-                                if (!assistantMessage) {
-                                    assistantMessage = {
-                                        id: "temp-assistant-" + Date.now(),
-                                        role: "assistant",
-                                        blocks: [],
-                                        mode: this.mode,
-                                        conversationId: this.activeConversationId,
-                                        content: null,
-                                        createdAt: new Date().toISOString(),
-                                    };
-                                }
-                                assistantMessage = {
-                                    ...assistantMessage,
-                                    blocks: [
-                                        ...(assistantMessage?.blocks ?? []),
-                                        /** @type {import("../../shared/types.js").MessageBlock} */ (
-                                            typedData.data
-                                        ),
-                                    ],
-                                };
-
-                                if (!assistantMessageAdded) {
-                                    this.messages = [...this.messages, assistantMessage];
-                                    assistantMessageAdded = true;
-                                } else {
-                                    this.messages = [
-                                        ...this.messages.slice(0, -1),
-                                        assistantMessage,
-                                    ];
-                                }
-                            } else if (typedData.type === "assistantComplete") {
-                                assistantMessage =
-                                    /** @type {import("../../shared/types.js").AssistantMessage} */ (
-                                        typedData.data
-                                    );
-                                if (!assistantMessageAdded) {
-                                    this.messages = [...this.messages, assistantMessage];
-                                    assistantMessageAdded = true;
-                                } else {
-                                    this.messages = [
-                                        ...this.messages.slice(0, -1),
-                                        assistantMessage,
-                                    ];
-                                }
-                            }
+                for await (const event of this._msgStore.parseSSEStream(body)) {
+                    if (event.type === "userMessage") {
+                        userMessage = event.data;
+                        messages = [...messages, userMessage];
+                        this._updateMsgState({ messages, responding: true });
+                    } else if (event.type === "assistantChunk") {
+                        if (!assistantMessage) {
+                            assistantMessage = {
+                                id: "temp-assistant-" + Date.now(),
+                                role: "assistant",
+                                blocks: [],
+                                mode: this._modeState.mode,
+                                conversationId: targetConvId,
+                                content: null,
+                                createdAt: new Date().toISOString(),
+                            };
                         }
+                        assistantMessage = {
+                            ...assistantMessage,
+                            blocks: [...(assistantMessage?.blocks ?? []), event.data],
+                        };
+
+                        if (!assistantMessageAdded) {
+                            messages = [...messages, assistantMessage];
+                            assistantMessageAdded = true;
+                        } else {
+                            messages = [...messages.slice(0, -1), assistantMessage];
+                        }
+                        this._updateMsgState({ messages, responding: true });
+                    } else if (event.type === "assistantComplete") {
+                        assistantMessage = event.data;
+                        if (!assistantMessageAdded) {
+                            messages = [...messages, assistantMessage];
+                            assistantMessageAdded = true;
+                        } else {
+                            messages = [...messages.slice(0, -1), assistantMessage];
+                        }
+                        this._updateMsgState({ messages, responding: true });
                     }
                 }
             } catch (err) {
@@ -501,7 +500,7 @@ class MainPage extends LitElement {
                     // Ignore error
                 }
             } finally {
-                this.responding = false;
+                this._updateMsgState({ messages: this._msgState.messages, responding: false });
                 this._currentAssistantController = null;
             }
         } catch {

--- a/client/pages/main-page.test.js
+++ b/client/pages/main-page.test.js
@@ -55,112 +55,148 @@ describe("main-page", () => {
     });
 
     it("should initialize with empty state", () => {
-        expect(element.conversations).toEqual([]);
-        expect(element.messages).toEqual([]);
-        expect(element.activeConversationId).toBe("");
-        // Note: loading is set to false after firstUpdated, so we check initial properties
-        expect(element.mode).toBe("player");
-        expect(element.sidebarExpanded).toBe(true);
+        expect(element._convState.conversations).toEqual([]);
+        expect(element._msgState.messages).toEqual([]);
+        expect(element._convState.activeConversationId).toBe("");
+        expect(element._modeState.mode).toBe("player");
+        expect(element._uiState.sidebarExpanded).toBe(true);
     });
 
     it("should filter messages by active conversation", () => {
-        element.messages = [
-            {
-                id: "1",
-                conversationId: "conv1",
-                content: "Test 1",
-                role: "user",
-                mode: "player",
-                createdAt: new Date().toISOString(),
-            },
-            {
-                id: "2",
-                conversationId: "conv2",
-                content: "Test 2",
-                role: "user",
-                mode: "player",
-                createdAt: new Date().toISOString(),
-            },
-            {
-                id: "3",
-                conversationId: "conv1",
-                content: "Test 3",
-                role: "user",
-                mode: "player",
-                createdAt: new Date().toISOString(),
-            },
-        ];
-        element.activeConversationId = "conv1";
+        element._msgState = {
+            messages: [
+                {
+                    id: "1",
+                    conversationId: "conv1",
+                    content: "Test 1",
+                    role: "user",
+                    mode: "player",
+                    createdAt: new Date().toISOString(),
+                },
+                {
+                    id: "2",
+                    conversationId: "conv2",
+                    content: "Test 2",
+                    role: "user",
+                    mode: "player",
+                    createdAt: new Date().toISOString(),
+                },
+                {
+                    id: "3",
+                    conversationId: "conv1",
+                    content: "Test 3",
+                    role: "user",
+                    mode: "player",
+                    createdAt: new Date().toISOString(),
+                },
+            ],
+            responding: false,
+        };
+        element._convState = {
+            conversations: [],
+            activeConversationId: "conv1",
+            loading: false,
+        };
 
-        expect(element.filteredMessages).toEqual([
+        const msgs = element._msgState.messages.filter(
+            (m) => m.conversationId === element._convState.activeConversationId,
+        );
+        expect(msgs).toEqual([
             expect.objectContaining({ id: "1", conversationId: "conv1" }),
             expect.objectContaining({ id: "3", conversationId: "conv1" }),
         ]);
     });
 
     it("should return empty array for non-existent conversation", () => {
-        element.messages = [
-            {
-                id: "1",
-                conversationId: "conv1",
-                content: "Test",
-                role: "user",
-                mode: "player",
-                createdAt: new Date().toISOString(),
-            },
-        ];
-        element.activeConversationId = "nonexistent";
-        expect(element.filteredMessages).toEqual([]);
+        element._msgState = {
+            messages: [
+                {
+                    id: "1",
+                    conversationId: "conv1",
+                    content: "Test",
+                    role: "user",
+                    mode: "player",
+                    createdAt: new Date().toISOString(),
+                },
+            ],
+            responding: false,
+        };
+        element._convState = {
+            conversations: [],
+            activeConversationId: "nonexistent",
+            loading: false,
+        };
+        const msgs = element._msgState.messages.filter(
+            (m) => m.conversationId === element._convState.activeConversationId,
+        );
+        expect(msgs).toEqual([]);
     });
 
     it("should switch mode correctly", () => {
         // Ensure initial state
-        element.mode = "player";
-        expect(element.mode).toBe("player");
+        element._modeState = { mode: "player" };
+        expect(element._modeState.mode).toBe("player");
 
         const event = new CustomEvent("mode-change", {
             detail: { mode: /** @type {import("../../shared/types.js").Mode} */ ("gm") },
         });
         element.handleModeChange(event);
-        // @ts-expect-error - mode is typed as "player" here, but we want to test with mode
-        expect(element.mode).toBe("gm");
+        expect(element._modeState.mode).toBe("gm");
     });
 
     it("should toggle sidebar", () => {
-        expect(element.sidebarExpanded).toBe(true);
+        expect(element._uiState.sidebarExpanded).toBe(true);
 
         const event = new CustomEvent("toggle-sidebar", { detail: { expanded: false } });
         element.handleSidebarToggle(event);
-        expect(element.sidebarExpanded).toBe(false);
+        expect(element._uiState.sidebarExpanded).toBe(false);
     });
 
     it("should handle select-conversation event", async () => {
-        element.activeConversationId = "conv1";
+        element._convState = {
+            conversations: [],
+            activeConversationId: "conv1",
+            loading: false,
+        };
 
-        const fetchMessagesMock = mock((_arg) => Promise.resolve([]));
-        // @ts-expect-error - override fetchMessages with our mock
-        element.fetchMessages = fetchMessagesMock;
+        // Mock fetch for messages fetch
+        // @ts-expect-error - override global fetch with our mock
+        globalThis.fetch = mock((url) => {
+            if (url.includes("/api/conversations/conv2/messages")) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ result: "success", data: [] }),
+                });
+            }
+            throw new Error(`Unexpected fetch URL: ${url}`);
+        });
 
         const event = new CustomEvent("select-conversation", { detail: { id: "conv2" } });
         await element.handleSelectConversation(event);
 
-        expect(element.activeConversationId).toBe("conv2");
-        expect(fetchMessagesMock).toHaveBeenCalled();
-        expect(fetchMessagesMock.mock.calls[0][0]).toBe("conv2");
+        expect(element._convState.activeConversationId).toBe("conv2");
     });
 
     it("should add user and assistant messages when sending", async () => {
-        element.activeConversationId = "conv1";
-        element.messages = [
-            {
-                id: "1",
-                conversationId: "conv1",
-                content: "Old",
-                role: "user",
-                mode: "player",
-                createdAt: new Date().toISOString(),
-            },
-        ];
+        element._convState = {
+            conversations: [{ id: "conv1", title: "Test" }],
+            activeConversationId: "conv1",
+            loading: false,
+        };
+        element._modeState = { mode: "player" };
+        element._msgState = {
+            messages: [
+                {
+                    id: "1",
+                    conversationId: "conv1",
+                    content: "Old",
+                    role: "user",
+                    mode: "player",
+                    createdAt: new Date().toISOString(),
+                },
+            ],
+            responding: false,
+        };
 
         const mockUserMessage = {
             id: "2",
@@ -217,17 +253,24 @@ describe("main-page", () => {
         const event = new CustomEvent("send-message", { detail: { text: "Test message" } });
         await element.handleSendMessage(event);
 
-        expect(element.messages.length).toBe(3);
-        expect(element.messages[1].content).toBe("Test message");
-        expect(element.messages[1].role).toBe("user");
-        expect(element.messages[2].role).toBe("assistant");
+        expect(element._msgState.messages.length).toBe(3);
+        expect(element._msgState.messages[1].content).toBe("Test message");
+        expect(element._msgState.messages[1].role).toBe("user");
+        expect(element._msgState.messages[2].role).toBe("assistant");
         // We check the blocks property directly
-        expect(element.messages[2].blocks).toEqual([{ type: "paragraph", text: "Mock response" }]);
+        expect(element._msgState.messages[2].blocks).toEqual([
+            { type: "paragraph", text: "Mock response" },
+        ]);
     });
 
     it("should set responding to true during send and false after", async () => {
-        element.activeConversationId = "conv1";
-        element.messages = [];
+        element._convState = {
+            conversations: [{ id: "conv1", title: "Test" }],
+            activeConversationId: "conv1",
+            loading: false,
+        };
+        element._modeState = { mode: "player" };
+        element._msgState = { messages: [], responding: false };
 
         const mockUserMessage = {
             id: "2",
@@ -276,18 +319,22 @@ describe("main-page", () => {
         const promise = element.handleSendMessage(event);
 
         // Check responding is true during the call
-        expect(element.responding).toBe(true);
+        expect(element._msgState.responding).toBe(true);
 
         await promise;
 
         // Check responding is false after the call
-        expect(element.responding).toBe(false);
+        expect(element._msgState.responding).toBe(false);
     });
 
     it("should create new conversation", async () => {
-        element.conversations = [
-            { id: "conv1", title: "Old", userId: "user1", createdAt: new Date().toISOString() },
-        ];
+        element._convState = {
+            conversations: [
+                { id: "conv1", title: "Old", userId: "user1", createdAt: new Date().toISOString() },
+            ],
+            activeConversationId: "conv1",
+            loading: false,
+        };
 
         const mockConv = {
             id: "conv2",
@@ -318,16 +365,18 @@ describe("main-page", () => {
 
         await element.handleNewChat();
 
-        expect(element.conversations.length).toBe(2);
-        expect(element.conversations[1].id).toBe("conv2");
-        expect(element.activeConversationId).toBe("conv2");
+        expect(element._convState.conversations.length).toBe(2);
+        expect(element._convState.conversations[1].id).toBe("conv2");
+        expect(element._convState.activeConversationId).toBe("conv2");
     });
 
     describe("landing page", () => {
         it("renders landing when no conversations and not loading", async () => {
             // Wait for firstUpdated to complete (sets loading=false)
             await new Promise((r) => setTimeout(r, 100));
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -347,8 +396,9 @@ describe("main-page", () => {
         it("focuses landing input", async () => {
             // Wait for firstUpdated to complete
             await new Promise((r) => setTimeout(r, 100));
-            element.loading = false;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -365,8 +415,9 @@ describe("main-page", () => {
         });
 
         it("does not render landing when loading", async () => {
-            element.loading = true;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: true };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -382,18 +433,25 @@ describe("main-page", () => {
                 userId: "u1",
                 createdAt: new Date().toISOString(),
             };
-            element.conversations = [conv];
-            element.activeConversationId = "c1";
-            element.messages = [
-                {
-                    id: "m1",
-                    conversationId: "c1",
-                    content: "Hello",
-                    role: "user",
-                    mode: "player",
-                    createdAt: new Date().toISOString(),
-                },
-            ];
+            element._convState = {
+                conversations: [conv],
+                activeConversationId: "c1",
+                loading: false,
+            };
+            element._msgState = {
+                messages: [
+                    {
+                        id: "m1",
+                        conversationId: "c1",
+                        content: "Hello",
+                        role: "user",
+                        mode: "player",
+                        createdAt: new Date().toISOString(),
+                    },
+                ],
+                responding: false,
+            };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -409,9 +467,13 @@ describe("main-page", () => {
                 userId: "u1",
                 createdAt: new Date().toISOString(),
             };
-            element.conversations = [conv];
-            element.activeConversationId = "c1";
-            element.messages = [];
+            element._convState = {
+                conversations: [conv],
+                activeConversationId: "c1",
+                loading: false,
+            };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -427,8 +489,9 @@ describe("main-page", () => {
             const submitSpy = mock(() => Promise.resolve());
             element.handleLandingSubmit = /** @type {any} */ (submitSpy);
 
-            element.loading = false;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -459,8 +522,9 @@ describe("main-page", () => {
             const submitSpy = mock(() => Promise.resolve());
             element.handleLandingSubmit = /** @type {any} */ (submitSpy);
 
-            element.loading = false;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const landingView = element.shadowRoot?.querySelector("landing-view");
@@ -495,10 +559,13 @@ describe("main-page", () => {
                 userId: "u1",
                 createdAt: new Date().toISOString(),
             };
-            element.conversations = [conv];
-            element.activeConversationId = "conv-existing";
-            element.messages = [];
-            element.loading = false;
+            element._convState = {
+                conversations: [conv],
+                activeConversationId: "conv-existing",
+                loading: false,
+            };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const mockUserMessage = {
@@ -533,17 +600,18 @@ describe("main-page", () => {
             const event = new CustomEvent("landing-submit", { detail: { text: "Hello existing" } });
             await element.handleLandingSubmit(event);
 
-            expect(element.conversations.length).toBe(1);
-            expect(element.activeConversationId).toBe("conv-existing");
-            expect(element.responding).toBe(false);
+            expect(element._convState.conversations.length).toBe(1);
+            expect(element._convState.activeConversationId).toBe("conv-existing");
+            expect(element._msgState.responding).toBe(false);
             expect(element._landingSubmitting).toBe(false);
         });
 
         it("submits landing prompt and swaps to normal UI", async () => {
             // Wait for firstUpdated to complete
             await new Promise((r) => setTimeout(r, 100));
-            element.loading = false;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             const mockConv = {
@@ -603,15 +671,16 @@ describe("main-page", () => {
             const event = new CustomEvent("landing-submit", { detail: { text: "Hello world" } });
             await element.handleLandingSubmit(event);
 
-            expect(element.conversations.length).toBe(1);
-            expect(element.conversations[0].id).toBe("conv-land");
-            expect(element.activeConversationId).toBe("conv-land");
+            expect(element._convState.conversations.length).toBe(1);
+            expect(element._convState.conversations[0].id).toBe("conv-land");
+            expect(element._convState.activeConversationId).toBe("conv-land");
             expect(element._landingSubmitting).toBe(false);
         });
 
         it("handles landing submit error gracefully", async () => {
-            element.loading = false;
-            element.conversations = [];
+            element._convState = { conversations: [], activeConversationId: "", loading: false };
+            element._msgState = { messages: [], responding: false };
+            element.requestUpdate();
             await element.updateComplete;
 
             // @ts-expect-error - override global fetch with our mock

--- a/client/stores/conversation-store.js
+++ b/client/stores/conversation-store.js
@@ -1,0 +1,49 @@
+import { createContext } from "@lit/context";
+
+import { client } from "../utils/rpc-client.js";
+
+/**
+ * @typedef {{
+ *   conversations: import("../../shared/types.js").Conversation[],
+ *   activeConversationId: string,
+ *   loading: boolean
+ * }} ConversationState
+ */
+
+/** @type {ReturnType<typeof import("@lit/context").createContext<ConversationState>>} */
+const conversationContext = createContext("conversation");
+
+/**
+ * Creates a conversation store with methods for managing conversation state.
+ * The store is stateless — all state is managed by the ContextProvider.
+ * @returns {{
+ *   fetchConversations: () => Promise<import("../../shared/types.js").Conversation[]>,
+ *   createConversation: (title: string) => Promise<import("../../shared/types.js").Conversation>,
+ * }}
+ */
+function createConversationStore() {
+    return {
+        /**
+         * @returns {Promise<import("../../shared/types.js").Conversation[]>}
+         */
+        async fetchConversations() {
+            const res = await client.api.conversations.$get();
+            const result = await res.json();
+            return /** @type {import("../../shared/types.js").Conversation[]} */ (result.data);
+        },
+
+        /**
+         * @param {string} title
+         * @returns {Promise<import("../../shared/types.js").Conversation>}
+         */
+        async createConversation(title) {
+            const res = await client.api.conversations.$post({
+                json: { title },
+            });
+            const conv = await res.json();
+            return /** @type {import("../../shared/types.js").Conversation} */ (conv.data);
+        },
+    };
+}
+
+export { conversationContext, createConversationStore };

--- a/client/stores/messages-store.js
+++ b/client/stores/messages-store.js
@@ -1,0 +1,95 @@
+import { createContext } from "@lit/context";
+
+import { client } from "../utils/rpc-client.js";
+
+/**
+ * @typedef {{
+ *   messages: import("../../shared/types.js").Message[],
+ *   responding: boolean
+ * }} MessagesState
+ */
+
+/**
+ * @typedef {{ type: "userMessage", data: import("../../shared/types.js").Message }} SSEUserMessageEvent
+ * @typedef {{ type: "assistantChunk", data: import("../../shared/types.js").MessageBlock }} SSEChunkEvent
+ * @typedef {{ type: "assistantComplete", data: import("../../shared/types.js").AssistantMessage }} SSECompleteEvent
+ * @typedef {SSEUserMessageEvent | SSEChunkEvent | SSECompleteEvent} SSEEvent
+ */
+
+/** @type {ReturnType<typeof import("@lit/context").createContext<MessagesState>>} */
+const messagesContext = createContext("messages");
+
+/**
+ * Creates a messages store with methods for managing message state.
+ * The store is stateless — all state is managed by the ContextProvider.
+ * @returns {{
+ *   fetchMessages: (convId: string) => Promise<import("../../shared/types.js").Message[]>,
+ *   parseSSEStream: (body: ReadableStream<Uint8Array>) => AsyncGenerator<SSEEvent>,
+ * }}
+ */
+function createMessagesStore() {
+    return {
+        /**
+         * @param {string} convId
+         * @returns {Promise<import("../../shared/types.js").Message[]>}
+         */
+        async fetchMessages(convId) {
+            const res = await client.api.conversations[":id"].messages.$get({
+                param: { id: convId },
+            });
+            const result = await res.json();
+            return /** @type {import("../../shared/types.js").Message[]} */ (result.data);
+        },
+
+        /**
+         * Parses an SSE ReadableStream into typed events.
+         * @param {ReadableStream<Uint8Array>} body
+         * @returns {AsyncGenerator<SSEEvent>}
+         */
+        async *parseSSEStream(body) {
+            const reader = body.getReader();
+            const decoder = new TextDecoder();
+
+            try {
+                while (true) {
+                    const result = await reader.read();
+                    if (result.done) {
+                        break;
+                    }
+                    const value = result.value;
+                    const chunk = decoder.decode(value, { stream: true });
+                    const lines = chunk.split("\n").filter(Boolean);
+                    for (const line of lines) {
+                        /** @type {unknown} */
+                        const data = JSON.parse(line);
+                        if (
+                            typeof data === "object" &&
+                            data !== null &&
+                            "type" in data &&
+                            typeof data.type === "string" &&
+                            "data" in data
+                        ) {
+                            /** @type {SSEEvent} */
+                            const typedData = /** @type {SSEEvent} */ (data);
+                            yield typedData;
+                        }
+                    }
+                }
+            } finally {
+                reader.releaseLock();
+            }
+        },
+    };
+}
+
+/**
+ * Filters messages by conversation ID.
+ * @param {import("../../shared/types.js").Message[]} messages
+ * @param {string} activeConversationId
+ * @returns {import("../../shared/types.js").Message[]}
+ */
+function filteredMessages(messages, activeConversationId) {
+    return messages.filter((message) => message.conversationId === activeConversationId);
+}
+
+export { messagesContext, createMessagesStore, filteredMessages };

--- a/client/stores/mode-store.js
+++ b/client/stores/mode-store.js
@@ -1,0 +1,32 @@
+import { createContext } from "@lit/context";
+
+/**
+ * @typedef {{
+ *   mode: import("../../shared/types.js").Mode
+ * }} ModeState
+ */
+
+/** @type {ReturnType<typeof import("@lit/context").createContext<ModeState>>} */
+const modeContext = createContext("mode");
+
+/**
+ * Creates a mode store with local-only mode persistence.
+ * Mode changes via the header toggle are local only (same as current behavior).
+ * PUT /api/users/me is only called from settings-dialog's save flow (unchanged).
+ * @returns {{
+ *   setMode: (mode: import("../../shared/types.js").Mode) => ModeState
+ * }}
+ */
+function createModeStore() {
+    return {
+        /**
+         * @param {import("../../shared/types.js").Mode} mode
+         * @returns {ModeState}
+         */
+        setMode(mode) {
+            return { mode };
+        },
+    };
+}
+
+export { modeContext, createModeStore };

--- a/client/stores/ui-store.js
+++ b/client/stores/ui-store.js
@@ -1,0 +1,49 @@
+import { createContext } from "@lit/context";
+
+/**
+ * @typedef {{
+ *   sidebarExpanded: boolean,
+ *   settingsOpen: boolean
+ * }} UIState
+ */
+
+/** @type {ReturnType<typeof import("@lit/context").createContext<UIState>>} */
+const uiContext = createContext("ui");
+
+/**
+ * Creates a UI store with methods for managing UI state.
+ * @returns {{
+ *   toggleSidebar: (current: UIState) => UIState,
+ *   openSettings: (current: UIState) => UIState,
+ *   closeSettings: (current: UIState) => UIState
+ * }}
+ */
+function createUIStore() {
+    return {
+        /**
+         * @param {UIState} current
+         * @returns {UIState}
+         */
+        toggleSidebar(current) {
+            return { ...current, sidebarExpanded: !current.sidebarExpanded };
+        },
+
+        /**
+         * @param {UIState} current
+         * @returns {UIState}
+         */
+        openSettings(current) {
+            return { ...current, settingsOpen: true };
+        },
+
+        /**
+         * @param {UIState} current
+         * @returns {UIState}
+         */
+        closeSettings(current) {
+            return { ...current, settingsOpen: false };
+        },
+    };
+}
+
+export { uiContext, createUIStore };

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,1 +1,24 @@
 declare module "https://esm.sh/@shoelace-style/shoelace*";
+
+declare module "@lit/context" {
+    export function createContext<ValueType>(key: string): {
+        __context__: unique symbol;
+        __value__: ValueType;
+    };
+
+    export class ContextProvider<ValueType> {
+        constructor(host: HTMLElement, options: { context: unknown; initialValue: ValueType });
+        setValue(value: ValueType): void;
+    }
+
+    export class ContextConsumer<ValueType> {
+        constructor(
+            host: HTMLElement,
+            options: {
+                context: unknown;
+                callback: (value: ValueType) => void;
+                subscribe?: boolean;
+            },
+        );
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     },
     "dependencies": {
         "@hono/zod-validator": "0.7.6",
+        "@lit/context": "1.1.2",
         "@shoelace-style/shoelace": "2.20.1",
         "@simplewebauthn/browser": "13.3.0",
         "@simplewebauthn/server": "13.3.0",


### PR DESCRIPTION
fixes #39 

## Summary

- Replace God-component main-page with 4 sliced Lit context stores (`conversation-store`, `messages-store`, `mode-store`, `ui-store`)
- Eliminate deep prop drilling — child components consume from context directly
- Extract reusable SSE parser into `messages-store` (removes 2 duplicate ~50-line blocks)
- `chat-view` reduced to pure layout shell; `chat-header` becomes pure event relay
- Clean up dead `mode` property in `profile-menu` and `conversation-menu`
- Fix `settings-dialog` to use `dialog.hide()` instead of local `this.open` mutation

## Test results

- `bun run check` — 0 errors
- `bunx oxlint .` — 0 warnings
- `bunx oxfmt . --check` — all formatted
- `bun run test` — 259 pass, 0 fail
- `bunx playwright test` — 42 pass (4 flaky on first attempt, all pass on retry — pre-existing timing)