### PR TITLE
add pre-commit hooks (format, lint, check, test) via simple-git-hooks (#65)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "oxlint": "1.61.0",
         "oxlint-tsgolint": "^0.22.1",
         "playwright": "1.59.1",
+        "simple-git-hooks": "^2.12.1",
       },
     },
   },
@@ -277,6 +278,8 @@
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
+
+    "simple-git-hooks": ["simple-git-hooks@2.13.1", "", { "bin": { "simple-git-hooks": "cli.js" } }, "sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "start": "bun run --hot ./server/index.js --development",
         "serve": "bun run ./server/index.js --development",
         "lint": "oxlint",
+        "prepare": "simple-git-hooks",
         "format": "oxfmt",
         "test": "bun test",
         "check": "tsgo -p jsconfig.json --noEmit",
@@ -41,6 +42,10 @@
         "oxfmt": "0.46.0",
         "oxlint": "1.61.0",
         "oxlint-tsgolint": "^0.22.1",
-        "playwright": "1.59.1"
+        "playwright": "1.59.1",
+        "simple-git-hooks": "^2.12.1"
+    },
+    "simple-git-hooks": {
+        "pre-commit": "sh scripts/pre-commit.sh"
     }
 }

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -e
+
+echo "━━━ pre-commit checks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━" >&2
+
+# Step 1: Format (auto-fix, then re-stage formatted files that were already staged)
+echo "  [1/4] formatting (oxfmt)..." >&2
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+bun run format
+# Re-stage only files that were already staged (to pick up format changes,
+# but not accidentally stage other dirty files)
+if [ -n "$STAGED_FILES" ]; then
+    echo "$STAGED_FILES" | xargs -r git add
+fi
+
+# Step 2: Lint
+echo "  [2/4] linting (oxlint)..." >&2
+bun run lint
+
+# Step 3: Type-check
+echo "  [3/4] type-checking (tsgo)..." >&2
+bun run check
+
+# Step 4: Tests
+echo "  [4/4] running tests (bun test)..." >&2
+bun run test
+
+echo "✓ all pre-commit checks passed" >&2


### PR DESCRIPTION
## Summary
- Add `simple-git-hooks` as pre-commit hook manager
- Run `format` → `lint` → `check` → `test` before every commit
- Format auto-fixes and re-stages files; lint/check/test block commit on failure
- Escape hatch: `git commit --no-verify` or `SKIP_SIMPLE_GIT_HOOKS=1`

Closes #65