### PR TITLE
Wire up RAG query pipeline for LLM context retrieval (#80)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
         "e2e": "playwright test",
         "e2e-local": "playwright test --project=chromium --retries=0 --ui",
         "gh:update-snapshots": "gh workflow run \"Update Snapshots\" --ref main",
-        "vector:dry-run": "bun scripts/create-vector-db.js --dry-run",
-        "import:dry-run": "bun scripts/import-foundry.js --dry-run"
+        "create:demo": "bun run create:demo:import-foundry && bun run create:demo:vector-db",
+        "create:demo:import-foundry": "bun ./scripts/import-foundry.js --pack pathfinder-bestiary --limit 10",
+        "create:demo:vector-db": "bun ./scripts/create-vector-db.js --model gemini-embedding-001 --limit 100 --batch-size 100",
+        "create:embeddings": "bun ./scripts/create-vector-db.js --model gemini-embedding-001"
     },
     "dependencies": {
         "@hono/zod-validator": "0.7.6",

--- a/scripts/create-vector-db.js
+++ b/scripts/create-vector-db.js
@@ -75,7 +75,7 @@ Options:
   --batch-size <n>    Embeddings per API call [default: 20]
   --db <path>         Source SQLite database [default: data/dev.sqlite]
   --vector-db <path>  Output vector database [default: data/vectors.sqlite]
-  --model <name>      Embedding model name [default: text-embedding-004]
+  --model <name>      Embedding model name [default: gemini-embedding-001]
   --dry-run           Generate chunks without calling the embedding API
   --help              Show this help message
 `;
@@ -90,7 +90,7 @@ const vectorArgsSchema = z.object({
     batchSize: z.coerce.number().int().positive().default(20),
     db: z.string().default("data/dev.sqlite"),
     vectorDb: z.string().default("data/vectors.sqlite"),
-    model: z.string().default("text-embedding-004"),
+    model: z.string().default("gemini-embedding-001"),
     dryRun: z.boolean().default(false),
 });
 

--- a/scripts/create-vector-db.test.js
+++ b/scripts/create-vector-db.test.js
@@ -72,6 +72,7 @@ describe("create-vector-db", () => {
         });
 
         it("uses defaults for missing args", () => {
+            delete process.env.GOOGLE_AI_API_KEY;
             const opts = parseVectorArgs(["bun", "script.js", "--dry-run"]);
 
             expect(opts.apiKey).toBeUndefined();
@@ -80,7 +81,7 @@ describe("create-vector-db", () => {
             expect(opts.batchSize).toBe(20);
             expect(opts.db).toBe("data/dev.sqlite");
             expect(opts.vectorDb).toBe("data/vectors.sqlite");
-            expect(opts.model).toBe("text-embedding-004");
+            expect(opts.model).toBe("gemini-embedding-001");
             expect(opts.dryRun).toBe(true);
         });
 

--- a/scripts/lib/google-ai-client.js
+++ b/scripts/lib/google-ai-client.js
@@ -11,7 +11,7 @@ const batchEmbedResponseSchema = z.object({
 /**
  * Creates embeddings for text chunks using Google's Generative AI API.
  * @param {string} apiKey - Google AI API key
- * @param {string} model - Model name (e.g. "text-embedding-004")
+ * @param {string} model - Model name (e.g. "gemini-embedding-001")
  * @param {string[]} texts - Array of text strings to embed
  * @returns {Promise<number[][]>} - Array of embedding vectors
  */

--- a/scripts/lib/google-ai-client.test.js
+++ b/scripts/lib/google-ai-client.test.js
@@ -24,12 +24,12 @@ describe("google-ai-client", () => {
             );
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            await createEmbeddings("test-api-key", "text-embedding-004", ["hello world"]);
+            await createEmbeddings("test-api-key", "gemini-embedding-001", ["hello world"]);
 
             expect(fetchMock).toHaveBeenCalled();
             const calls = /** @type {string[][]} */ (/** @type {unknown} */ (fetchMock.mock.calls));
             expect(calls[0][0]).toBe(
-                "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:batchEmbedContents?key=test-api-key",
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-001:batchEmbedContents?key=test-api-key",
             );
         });
 
@@ -46,7 +46,7 @@ describe("google-ai-client", () => {
             );
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            await createEmbeddings("key", "text-embedding-004", ["text 1", "text 2"]);
+            await createEmbeddings("key", "gemini-embedding-001", ["text 1", "text 2"]);
 
             const calls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock.mock.calls)
@@ -58,11 +58,11 @@ describe("google-ai-client", () => {
             const body = JSON.parse(/** @type {string} */ (opts.body));
             expect(body.requests).toHaveLength(2);
             expect(body.requests[0]).toEqual({
-                model: "models/text-embedding-004",
+                model: "models/gemini-embedding-001",
                 content: { parts: [{ text: "text 1" }] },
             });
             expect(body.requests[1]).toEqual({
-                model: "models/text-embedding-004",
+                model: "models/gemini-embedding-001",
                 content: { parts: [{ text: "text 2" }] },
             });
         });
@@ -78,7 +78,7 @@ describe("google-ai-client", () => {
                 }),
             );
 
-            const result = await createEmbeddings("key", "text-embedding-004", [
+            const result = await createEmbeddings("key", "gemini-embedding-001", [
                 "text 1",
                 "text 2",
             ]);
@@ -98,7 +98,7 @@ describe("google-ai-client", () => {
                 }),
             );
 
-            expect(createEmbeddings("bad-key", "text-embedding-004", ["test"])).rejects.toThrow(
+            expect(createEmbeddings("bad-key", "gemini-embedding-001", ["test"])).rejects.toThrow(
                 "Google AI API error: 400 Bad Request: invalid API key",
             );
         });
@@ -112,7 +112,7 @@ describe("google-ai-client", () => {
                 }),
             );
 
-            expect(createEmbeddings("key", "text-embedding-004", ["test"])).rejects.toThrow(
+            expect(createEmbeddings("key", "gemini-embedding-001", ["test"])).rejects.toThrow(
                 "Google AI API error: 429 Rate limit exceeded",
             );
         });
@@ -127,7 +127,7 @@ describe("google-ai-client", () => {
             );
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            const result = await createEmbeddings("key", "text-embedding-004", []);
+            const result = await createEmbeddings("key", "gemini-embedding-001", []);
 
             expect(result).toEqual([]);
             // Should not call fetch for empty input

--- a/server/index.js
+++ b/server/index.js
@@ -12,15 +12,29 @@ import { authRouter } from "./routes/auth.js";
 import { conversationsRouter } from "./routes/conversations.js";
 import { ruleItemsRouter } from "./routes/rule-items.js";
 import { usersRouter } from "./routes/users.js";
+import { openVectorDb } from "./utils/vector-store.js";
 
 /** @typedef {import("../shared/hono-env.js").AppEnv} AppEnv */
 
 // Seed database
 seedIfNeeded(db);
 
+// Initialize vector DB
+const vectorDb = openVectorDb();
+if (vectorDb) {
+    const chunkCount = Number(
+        vectorDb.query("SELECT COUNT(*) as count FROM vector_chunks").get().count,
+    );
+    // oxlint-disable-next-line no-console -- startup diagnostic
+    console.log(`Vector DB loaded: ${chunkCount} chunks available`);
+} else {
+    // oxlint-disable-next-line no-console -- startup diagnostic
+    console.log("Vector DB not found at data/vectors.sqlite — RAG context retrieval disabled");
+}
+
 const app = new Hono()
-    // Database middleware (sets db in context for all routes)
-    .use("/api/*", databaseMiddleware())
+    // Database middleware (sets db and vectorDb in context for all routes)
+    .use("/api/*", databaseMiddleware({ vectorDb }))
     // Auth routes (no session required for most)
     .route("/api/auth", authRouter)
     // Session-protected API routes

--- a/server/middleware/database.js
+++ b/server/middleware/database.js
@@ -3,16 +3,18 @@ import { db as defaultDb } from "../db/database.js";
 /**
  * Hono middleware that sets the database instance in context.
  * This allows tests to override the database without mocking.
- * @param {{ database?: import("bun:sqlite").Database }} options - If database is provided, uses that instead of default db.
+ * @param {{ database?: import("bun:sqlite").Database, vectorDb?: import("bun:sqlite").Database | null }} options - If database is provided, uses that instead of default db.
  */
 export function databaseMiddleware(options = {}) {
     const database = options.database || defaultDb;
+    const vectorDb = options.vectorDb ?? null;
 
     return async (
         /** @type {import("hono").Context} */ c,
         /** @type {import("hono").Next} */ next,
     ) => {
         c.set("db", database);
+        c.set("vectorDb", vectorDb);
         return next();
     };
 }

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -3,13 +3,18 @@ import { Hono } from "hono";
 
 import { createMessageSchema } from "../../shared/schemas.js";
 import * as queries from "../db/queries.js";
-import { getDb, getUserId } from "../utils/context.js";
+import { getDb, getUserId, getVectorDb } from "../utils/context.js";
+import { buildSystemPrompt, streamLlmResponse } from "../utils/llm-client.js";
 import { streamMockResponse } from "../utils/mock-response.js";
+import { queryRagContext } from "../utils/rag-query.js";
 import { paramSchema } from "./conversations-schema.js";
 
 const validateId = zValidator("param", paramSchema);
 
 let firstMessageCounter = 0;
+
+// Gate logic: use mock when no API key or MOCK_GOOGLE_AI=1
+const useMock = () => process.env.MOCK_GOOGLE_AI === "1" || !process.env.GOOGLE_AI_API_KEY;
 
 export const messagesRouter = new Hono()
     .get("/", validateId, async (c) => {
@@ -73,7 +78,22 @@ export const messagesRouter = new Hono()
 
                     const blocks = [];
                     try {
-                        for await (const block of streamMockResponse()) {
+                        /** @type {AsyncGenerator<import("../../shared/types.js").MessageBlock, void, unknown>} */
+                        let blockGenerator;
+                        if (useMock()) {
+                            blockGenerator = streamMockResponse();
+                        } else {
+                            // TODO: Pass conversation history (last N messages) for multi-turn context
+                            const vectorDb = getVectorDb(c);
+                            const ragContext = await queryRagContext(data.content, {
+                                vectorDb,
+                                topN: 5,
+                                threshold: 0.3,
+                            });
+                            const systemPrompt = buildSystemPrompt(ragContext, data.mode);
+                            blockGenerator = streamLlmResponse(systemPrompt, data.content);
+                        }
+                        for await (const block of blockGenerator) {
                             blocks.push(block);
                             controller.enqueue(
                                 JSON.stringify({ type: "assistantChunk", data: block }) + "\n",

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -98,11 +98,9 @@ export const messagesRouter = new Hono()
                             controller.enqueue(
                                 JSON.stringify({ type: "assistantChunk", data: block }) + "\n",
                             );
-                            // Add additional delay here
-                            await new Promise((resolve) => setTimeout(resolve, 100));
                         }
-                    } catch {
-                        // Streaming interrupted
+                    } catch (error) {
+                        console.error("Error streaming assistant response:", error);
                     } finally {
                         // Save assistant message to DB
                         const assistantMsg = queries.createMessage(db, {

--- a/server/utils/context.js
+++ b/server/utils/context.js
@@ -27,3 +27,11 @@ export function getUserId(c) {
 export function getSessionId(c) {
     return /** @type {string} */ (c.get("sessionId"));
 }
+
+/**
+ * @param {import("hono").Context} c
+ * @returns {import("bun:sqlite").Database | null}
+ */
+export function getVectorDb(c) {
+    return /** @type {import("bun:sqlite").Database | null} */ (c.get("vectorDb"));
+}

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -147,13 +147,103 @@ function splitIntoBlocks(text) {
 
     return blocks;
 }
+/**
+ * Fetches the raw stream from the Gemini API.
+ *
+ * @param {string} model
+ * @param {string} apiKey
+ * @param {string} systemPrompt
+ * @param {string} userMessage
+ * @returns {Promise<ReadableStream<Uint8Array>>}
+ */
+async function getGeminiStream(model, apiKey, systemPrompt, userMessage) {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${apiKey}`;
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            contents: [{ role: "user", parts: [{ text: userMessage }] }],
+            systemInstruction: { parts: [{ text: systemPrompt }] },
+            generationConfig: { temperature: 0.7, maxOutputTokens: 2048 },
+        }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Gemini API Error (${response.status}): ${errorText}`);
+    }
+
+    if (!response.body) {
+        throw new Error("Gemini API response body is empty.");
+    }
+
+    return response.body;
+}
+/**
+ * Parses a single line of SSE data.
+ *
+ * @param {string} line
+ * @returns {string | null}
+ */
+function processSseLine(line) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith("data: ")) {
+        return null;
+    }
+
+    const data = trimmed.slice(6);
+    if (data === "[DONE]") {
+        return null;
+    }
+
+    try {
+        return parseGeminiSseChunk(data);
+    } catch (e) {
+        throw new Error(`SSE Parse Error: ${e instanceof Error ? e.message : String(e)}`);
+    }
+}
 
 /**
- * Streams an LLM response, either from the Gemini API or the mock response generator.
- * Yields MessageBlock objects as they become available.
+ * Transforms a ReadableStream into a generator of text chunks.
  *
- * @param {string} systemPrompt - The system instruction for the LLM.
- * @param {string} userMessage - The user's message text.
+ * @param {ReadableStream<Uint8Array>} stream
+ * @returns {AsyncGenerator<string, void, unknown>}
+ */
+async function* parseSseStream(stream) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let sseBuffer = "";
+
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            sseBuffer += decoder.decode(value, { stream: !done });
+
+            const lines = sseBuffer.split(/\r?\n/);
+            sseBuffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+                const text = processSseLine(line);
+                if (text) {
+                    yield text;
+                }
+            }
+
+            if (done) {
+                break;
+            }
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+/**
+ * Streams an LLM response and yields MessageBlock objects.
+ *
+ * @param {string} systemPrompt
+ * @param {string} userMessage
  * @param {{ model?: string, apiKey?: string }} [options]
  * @returns {AsyncGenerator<MessageBlock, void, unknown>}
  */
@@ -161,89 +251,41 @@ export async function* streamLlmResponse(systemPrompt, userMessage, options = {}
     const apiKey = options.apiKey ?? process.env.GOOGLE_AI_API_KEY ?? "";
     const model = options.model ?? RAG_CONFIG.LLM_MODEL;
 
-    // Mock mode: no API key or MOCK_GOOGLE_AI=1
     if (!apiKey || process.env.MOCK_GOOGLE_AI === "1") {
         yield* streamMockResponse();
         return;
     }
 
-    // Real API call
+    let accumulatedText = "";
+    let yieldedBlocksCount = 0;
+
     try {
-        const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${apiKey}`;
+        const stream = await getGeminiStream(model, apiKey, systemPrompt, userMessage);
 
-        const response = await fetch(url, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                contents: [{ role: "user", parts: [{ text: userMessage }] }],
-                systemInstruction: { parts: [{ text: systemPrompt }] },
-                generationConfig: { temperature: 0.7, maxOutputTokens: 2048 },
-            }),
-        });
+        for await (const textChunk of parseSseStream(stream)) {
+            accumulatedText += textChunk;
 
-        if (!response.ok || !response.body) {
-            // oxlint-disable-next-line no-console -- diagnostic for LLM fallback
-            console.warn(`LLM API error: ${response.status} ${await response.text()}`);
-            yield* streamMockResponse();
-            return;
-        }
+            /** @type {MessageBlock[]} */
+            const currentBlocks = splitIntoBlocks(accumulatedText);
 
-        // Parse SSE stream
-        const reader = response.body.getReader();
-        const decoder = new TextDecoder();
-        let accumulatedText = "";
-        let yieldedBlocks = 0;
-        /** @type {string} */
-        let sseBuffer = "";
-
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) {
-                break;
-            }
-
-            sseBuffer += decoder.decode(value, { stream: true });
-
-            // Parse SSE events (double newline delimited)
-            const events = sseBuffer.split("\n\n");
-            sseBuffer = /** @type {string} */ (events.pop());
-
-            for (const event of events) {
-                for (const line of event.split("\n")) {
-                    if (line.startsWith("data: ")) {
-                        const data = line.slice(6);
-                        if (data === "[DONE]") {
-                            continue;
-                        }
-                        const text = parseGeminiSseChunk(data);
-                        if (text) {
-                            accumulatedText += text;
-                        }
-                    }
-                }
-            }
-
-            // Periodically yield blocks from accumulated text
-            const blocks = splitIntoBlocks(accumulatedText);
-            for (let i = yieldedBlocks; i < blocks.length; i++) {
-                yield blocks[i];
-                yieldedBlocks++;
+            // Yield only fully completed blocks to prevent rendering partial JSON/markdown
+            while (yieldedBlocksCount < currentBlocks.length - 1) {
+                yield currentBlocks[yieldedBlocksCount++];
             }
         }
 
-        // Yield any remaining text as final blocks
+        // Final yield for the remaining blocks
+        /** @type {MessageBlock[]} */
         const finalBlocks = splitIntoBlocks(accumulatedText);
-        for (let i = yieldedBlocks; i < finalBlocks.length; i++) {
-            yield finalBlocks[i];
-        }
-
-        // If no blocks were yielded at all, wrap as single paragraph
-        if (yieldedBlocks === 0 && accumulatedText.trim()) {
-            yield { type: "paragraph", text: accumulatedText.trim() };
+        while (yieldedBlocksCount < finalBlocks.length) {
+            yield finalBlocks[yieldedBlocksCount++];
         }
     } catch (error) {
-        // oxlint-disable-next-line no-console -- diagnostic for LLM fallback
-        console.warn(`LLM API error: ${error instanceof Error ? error.message : String(error)}`);
-        yield* streamMockResponse();
+        yield* [
+            {
+                type: "paragraph",
+                text: `Sorry, I'm having trouble generating a response right now. Please try again later. (Error details: ${error instanceof Error ? error.message : String(error)})`,
+            },
+        ];
     }
 }

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -1,0 +1,249 @@
+import { RAG_CONFIG } from "../../shared/constants.js";
+import { streamMockResponse } from "./mock-response.js";
+
+/**
+ * @typedef {import("../../shared/types.js").MessageBlock} MessageBlock
+ * @typedef {import("../../shared/types.js").RagContext} RagContext
+ * @typedef {import("../../shared/types.js").Mode} Mode
+ */
+
+/**
+ * Builds the system prompt for the LLM with role, mode guidance, and RAG context.
+ * @param {RagContext} ragContext - Retrieved context from RAG pipeline.
+ * @param {Mode} mode - Player or GM mode.
+ * @returns {string}
+ */
+export function buildSystemPrompt(ragContext, mode) {
+    const modeGuidance =
+        mode === "gm"
+            ? "You are assisting a Game Master. Focus on rules interpretation, NPC stat blocks, encounter building, and GM tips. Be comprehensive and provide page references when possible."
+            : "You are assisting a player. Focus on helping them understand their character's abilities, rules for their actions, and gameplay tips. Keep answers concise and actionable.";
+
+    /** @type {string[]} */
+    const parts = [
+        `You are a Pathfinder 2e rules assistant. ${modeGuidance}`,
+        "",
+        "Always cite the specific rule or source when possible. If you're unsure about a rule, say so rather than guessing.",
+        "Format your responses clearly using paragraphs, callouts for key rules, and lists for multiple items.",
+    ];
+
+    if (ragContext.contextText) {
+        parts.push("", ragContext.contextText);
+    }
+
+    return parts.join("\n");
+}
+
+/**
+ * @typedef {{ candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> }} GeminiSseChunk
+ */
+
+/**
+ * Parses Gemini SSE streaming response text into accumulated text.
+ * @param {string} sseText
+ * @returns {string}
+ */
+function parseGeminiSseChunk(sseText) {
+    try {
+        const parsed = /** @type {GeminiSseChunk} */ (JSON.parse(sseText));
+        const text = parsed?.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+        return text;
+    } catch {
+        return "";
+    }
+}
+
+/**
+ * Splits LLM response text into MessageBlock objects.
+ * Simple heuristic: split on double-newlines for paragraphs,
+ * detect **Title:** patterns for callouts, detect - Item: patterns for lists.
+ * @param {string} text
+ * @returns {MessageBlock[]}
+ */
+function splitIntoBlocks(text) {
+    if (!text.trim()) {
+        return [];
+    }
+
+    const lines = text.split("\n");
+    /** @type {MessageBlock[]} */
+    const blocks = [];
+    /** @type {string[]} */
+    let currentParagraph = [];
+
+    /**
+     * @param {string} line
+     * @returns {{ title: string, text: string } | null}
+     */
+    function tryParseCallout(line) {
+        const match = line.match(/^\*\*(.+?)\*\*:?\s*(.*)/);
+        if (match) {
+            return { title: match[1], text: match[2] };
+        }
+        return null;
+    }
+
+    for (const line of lines) {
+        // Empty line = paragraph break
+        if (line.trim() === "") {
+            if (currentParagraph.length > 0) {
+                const text = currentParagraph.join(" ").trim();
+                if (text) {
+                    blocks.push({ type: "paragraph", text });
+                }
+                currentParagraph = [];
+            }
+            continue;
+        }
+
+        // Check for callout pattern: **Title:** rest of line
+        const callout = tryParseCallout(line);
+        if (callout) {
+            // Flush current paragraph first
+            if (currentParagraph.length > 0) {
+                const text = currentParagraph.join(" ").trim();
+                if (text) {
+                    blocks.push({ type: "paragraph", text });
+                }
+                currentParagraph = [];
+            }
+            blocks.push({ type: "callout", title: callout.title, text: callout.text });
+            continue;
+        }
+
+        // Check for list pattern: - Item or * Item
+        if (/^[-*]\s+/.test(line.trim())) {
+            // Flush current paragraph first
+            if (currentParagraph.length > 0) {
+                const text = currentParagraph.join(" ").trim();
+                if (text) {
+                    blocks.push({ type: "paragraph", text });
+                }
+                currentParagraph = [];
+            }
+
+            // Try to find or create a list block
+            const itemText = line.trim().replace(/^[-*]\s+/, "");
+            const lastBlock = blocks[blocks.length - 1];
+            if (lastBlock && lastBlock.type === "list") {
+                lastBlock.items.push({ title: itemText });
+            } else {
+                blocks.push({ type: "list", items: [{ title: itemText }] });
+            }
+            continue;
+        }
+
+        // Regular text — accumulate into current paragraph
+        currentParagraph.push(line.trim());
+    }
+
+    // Flush remaining paragraph
+    if (currentParagraph.length > 0) {
+        const text = currentParagraph.join(" ").trim();
+        if (text) {
+            blocks.push({ type: "paragraph", text });
+        }
+    }
+
+    return blocks;
+}
+
+/**
+ * Streams an LLM response, either from the Gemini API or the mock response generator.
+ * Yields MessageBlock objects as they become available.
+ *
+ * @param {string} systemPrompt - The system instruction for the LLM.
+ * @param {string} userMessage - The user's message text.
+ * @param {{ model?: string, apiKey?: string }} [options]
+ * @returns {AsyncGenerator<MessageBlock, void, unknown>}
+ */
+export async function* streamLlmResponse(systemPrompt, userMessage, options = {}) {
+    const apiKey = options.apiKey ?? process.env.GOOGLE_AI_API_KEY ?? "";
+    const model = options.model ?? RAG_CONFIG.LLM_MODEL;
+
+    // Mock mode: no API key or MOCK_GOOGLE_AI=1
+    if (!apiKey || process.env.MOCK_GOOGLE_AI === "1") {
+        yield* streamMockResponse();
+        return;
+    }
+
+    // Real API call
+    try {
+        const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${apiKey}`;
+
+        const response = await fetch(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                contents: [{ role: "user", parts: [{ text: userMessage }] }],
+                systemInstruction: { parts: [{ text: systemPrompt }] },
+                generationConfig: { temperature: 0.7, maxOutputTokens: 2048 },
+            }),
+        });
+
+        if (!response.ok || !response.body) {
+            // oxlint-disable-next-line no-console -- diagnostic for LLM fallback
+            console.warn(`LLM API error: ${response.status} ${await response.text()}`);
+            yield* streamMockResponse();
+            return;
+        }
+
+        // Parse SSE stream
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let accumulatedText = "";
+        let yieldedBlocks = 0;
+        /** @type {string} */
+        let sseBuffer = "";
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) {
+                break;
+            }
+
+            sseBuffer += decoder.decode(value, { stream: true });
+
+            // Parse SSE events (double newline delimited)
+            const events = sseBuffer.split("\n\n");
+            sseBuffer = /** @type {string} */ (events.pop());
+
+            for (const event of events) {
+                for (const line of event.split("\n")) {
+                    if (line.startsWith("data: ")) {
+                        const data = line.slice(6);
+                        if (data === "[DONE]") {
+                            continue;
+                        }
+                        const text = parseGeminiSseChunk(data);
+                        if (text) {
+                            accumulatedText += text;
+                        }
+                    }
+                }
+            }
+
+            // Periodically yield blocks from accumulated text
+            const blocks = splitIntoBlocks(accumulatedText);
+            for (let i = yieldedBlocks; i < blocks.length; i++) {
+                yield blocks[i];
+                yieldedBlocks++;
+            }
+        }
+
+        // Yield any remaining text as final blocks
+        const finalBlocks = splitIntoBlocks(accumulatedText);
+        for (let i = yieldedBlocks; i < finalBlocks.length; i++) {
+            yield finalBlocks[i];
+        }
+
+        // If no blocks were yielded at all, wrap as single paragraph
+        if (yieldedBlocks === 0 && accumulatedText.trim()) {
+            yield { type: "paragraph", text: accumulatedText.trim() };
+        }
+    } catch (error) {
+        // oxlint-disable-next-line no-console -- diagnostic for LLM fallback
+        console.warn(`LLM API error: ${error instanceof Error ? error.message : String(error)}`);
+        yield* streamMockResponse();
+    }
+}

--- a/server/utils/llm-client.test.js
+++ b/server/utils/llm-client.test.js
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+
+import { buildSystemPrompt, streamLlmResponse } from "./llm-client.js";
+
+describe("llm-client", () => {
+    const originalApiKey = process.env.GOOGLE_AI_API_KEY;
+    const originalMockAi = process.env.MOCK_GOOGLE_AI;
+
+    afterEach(() => {
+        if (originalApiKey !== undefined) {
+            process.env.GOOGLE_AI_API_KEY = originalApiKey;
+        } else {
+            delete process.env.GOOGLE_AI_API_KEY;
+        }
+        if (originalMockAi !== undefined) {
+            process.env.MOCK_GOOGLE_AI = originalMockAi;
+        } else {
+            delete process.env.MOCK_GOOGLE_AI;
+        }
+    });
+
+    describe("streamLlmResponse", () => {
+        it("delegates to streamMockResponse when MOCK_GOOGLE_AI=1", async () => {
+            process.env.MOCK_GOOGLE_AI = "1";
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            const blocks = [];
+            for await (const block of streamLlmResponse("system prompt", "user message")) {
+                blocks.push(block);
+            }
+
+            expect(blocks.length).toBeGreaterThan(0);
+            // Verify blocks are valid MessageBlock types
+            for (const block of blocks) {
+                expect(["paragraph", "callout", "list", "stat-block"]).toContain(block.type);
+            }
+        });
+
+        it("delegates to streamMockResponse when no API key is set", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            const blocks = [];
+            for await (const block of streamLlmResponse("system prompt", "user message")) {
+                blocks.push(block);
+            }
+
+            expect(blocks.length).toBeGreaterThan(0);
+        });
+
+        it("falls back to mock response when API call fails", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            // Don't set MOCK_GOOGLE_AI — force real API path but mock fetch to fail
+            delete process.env.MOCK_GOOGLE_AI;
+
+            // Mock global fetch to simulate API failure
+            const originalFetch = globalThis.fetch;
+            // oxlint-disable-next-line no-explicit-any -- type cast needed for mock fetch
+            globalThis.fetch = /** @type {any} */ (
+                mock(() => Promise.resolve(new Response("Internal Server Error", { status: 500 })))
+            );
+
+            const blocks = [];
+            for await (const block of streamLlmResponse("system prompt", "user message")) {
+                blocks.push(block);
+            }
+
+            expect(blocks.length).toBeGreaterThan(0);
+
+            // Restore fetch
+            globalThis.fetch = originalFetch;
+        });
+
+        it("yields blocks from Gemini API when streaming succeeds", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            delete process.env.MOCK_GOOGLE_AI;
+
+            // Create a mock SSE stream that simulates Gemini response
+            const sseData = JSON.stringify({
+                candidates: [
+                    {
+                        content: {
+                            parts: [{ text: "This is a test response from the LLM." }],
+                        },
+                    },
+                ],
+            });
+
+            const mockStream = new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new TextEncoder().encode(`data: ${sseData}\n\n`));
+                    controller.close();
+                },
+            });
+
+            const originalFetch = globalThis.fetch;
+            // oxlint-disable-next-line no-explicit-any -- type cast needed for mock fetch
+            globalThis.fetch = /** @type {any} */ (
+                mock(() =>
+                    Promise.resolve(
+                        new Response(mockStream, {
+                            status: 200,
+                            headers: { "Content-Type": "text/event-stream" },
+                        }),
+                    ),
+                )
+            );
+
+            const blocks = [];
+            for await (const block of streamLlmResponse("system prompt", "user message")) {
+                blocks.push(block);
+            }
+
+            expect(blocks.length).toBeGreaterThan(0);
+            expect(blocks[0].type).toBe("paragraph");
+
+            // Restore fetch
+            globalThis.fetch = originalFetch;
+        });
+    });
+
+    describe("buildSystemPrompt", () => {
+        it("includes role instruction and mode guidance for player", () => {
+            const prompt = buildSystemPrompt({ contextText: "", sources: [] }, "player");
+            expect(prompt).toContain("Pathfinder 2e");
+            expect(prompt).toContain("player");
+        });
+
+        it("includes mode guidance for GM", () => {
+            const prompt = buildSystemPrompt({ contextText: "", sources: [] }, "gm");
+            expect(prompt).toContain("Pathfinder 2e");
+            expect(prompt).toContain("Game Master");
+        });
+
+        it("includes RAG context when provided", () => {
+            const ragContext = {
+                contextText: "<retrieved-context>Fireball is a spell</retrieved-context>",
+                sources: [{ name: "Fireball", type: "spell", score: 0.95 }],
+            };
+            const prompt = buildSystemPrompt(ragContext, "player");
+            expect(prompt).toContain("Fireball is a spell");
+        });
+
+        it("works without RAG context (empty contextText)", () => {
+            const prompt = buildSystemPrompt({ contextText: "", sources: [] }, "player");
+            expect(prompt).toContain("Pathfinder 2e");
+            expect(prompt.includes("retrieved-context")).toBe(false);
+        });
+    });
+});

--- a/server/utils/rag-query.js
+++ b/server/utils/rag-query.js
@@ -128,7 +128,8 @@ export async function queryRagContext(userPrompt, options = {}) {
         }));
 
         return { contextText, sources };
-    } catch {
+    } catch (error) {
+        console.error("Error in queryRagContext:", error);
         // Never throw — degrade gracefully
         return { contextText: "", sources: [] };
     }

--- a/server/utils/rag-query.js
+++ b/server/utils/rag-query.js
@@ -1,0 +1,135 @@
+import { createEmbeddings } from "../../scripts/lib/google-ai-client.js";
+import { RAG_CONFIG } from "../../shared/constants.js";
+import { cosineSimilarity, getAllChunkEmbeddings } from "./vector-store.js";
+
+/**
+ * @typedef {import("../../shared/types.js").RagContext} RagContext
+ * @typedef {import("../../shared/types.js").RagSource} RagSource
+ */
+
+/**
+ * Generates a deterministic fake embedding from a string.
+ * Used when MOCK_GOOGLE_AI=1 to avoid API calls in tests.
+ * @param {string} text
+ * @returns {number[]}
+ */
+function fakeEmbedding(text) {
+    // Simple hash-based deterministic embedding for 768 dimensions
+    /** @type {number[]} */
+    const embedding = [];
+    for (let i = 0; i < 768; i++) {
+        embedding.push(0);
+    }
+    for (let i = 0; i < text.length; i++) {
+        const charCode = text.charCodeAt(i);
+        embedding[i % 768] += charCode / 65535;
+    }
+    // Normalize to unit length
+    const norm = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
+    if (norm > 0) {
+        for (let i = 0; i < embedding.length; i++) {
+            embedding[i] /= norm;
+        }
+    }
+    return embedding;
+}
+
+/**
+ * Convenience wrapper that creates a single embedding from a text prompt.
+ * @param {string} prompt - The text to embed.
+ * @param {string} apiKey - Google AI API key.
+ * @param {string} model - Embedding model name.
+ * @returns {Promise<number[]>}
+ */
+export async function createSingleEmbedding(prompt, apiKey, model) {
+    if (process.env.MOCK_GOOGLE_AI === "1") {
+        return fakeEmbedding(prompt);
+    }
+    const embeddings = await createEmbeddings(apiKey, model, [prompt]);
+    return embeddings[0];
+}
+
+/**
+ * Orchestrates the full RAG pipeline: embed → search → deduplicate → format.
+ *
+ * @param {string} userPrompt - The user's question.
+ * @param {{ vectorDb?: import("bun:sqlite").Database | null, topN?: number, threshold?: number, apiKey?: string, model?: string }} options
+ * @returns {Promise<RagContext>}
+ */
+export async function queryRagContext(userPrompt, options = {}) {
+    const vectorDb = options.vectorDb ?? null;
+    const topN = options.topN ?? RAG_CONFIG.TOP_N;
+    const threshold = options.threshold ?? RAG_CONFIG.SIMILARITY_THRESHOLD;
+    const apiKey = options.apiKey ?? process.env.GOOGLE_AI_API_KEY ?? "";
+    const model = options.model ?? RAG_CONFIG.EMBEDDING_MODEL;
+
+    // Graceful degradation: no vector DB or no API key
+    if (!vectorDb) {
+        return { contextText: "", sources: [] };
+    }
+    if (!apiKey) {
+        return { contextText: "", sources: [] };
+    }
+
+    try {
+        // Step 1: Embed the user prompt
+        const queryEmbedding = await createSingleEmbedding(userPrompt, apiKey, model);
+
+        // Step 2: Get all chunks and compute similarity
+        const allChunks = getAllChunkEmbeddings(vectorDb);
+
+        /** @type {Array<{ chunk: typeof allChunks[0], score: number }>} */
+        const scored = [];
+        for (const chunk of allChunks) {
+            const score = cosineSimilarity(queryEmbedding, chunk.embedding);
+            if (score >= threshold) {
+                scored.push({ chunk, score });
+            }
+        }
+
+        // Sort by descending score
+        scored.sort((a, b) => b.score - a.score);
+
+        // Step 3: Deduplicate by rule_item_id — keep only highest-scoring chunk per group
+        /** @type {Map<string, { chunk: typeof allChunks[0], score: number }>} */
+        const deduped = new Map();
+        for (const entry of scored) {
+            const key = entry.chunk.ruleItemId;
+            if (!deduped.has(key)) {
+                deduped.set(key, entry);
+            }
+        }
+
+        // Take top-N after deduplication
+        const topResults = [...deduped.values()].slice(0, topN);
+
+        if (topResults.length === 0) {
+            return { contextText: "", sources: [] };
+        }
+
+        // Step 4: Build context text
+        const contextParts = topResults.map((entry) => {
+            const { chunk } = entry;
+            return `--- Source: ${chunk.ruleItemName} (${chunk.ruleItemType}) ---\n${chunk.text}`;
+        });
+
+        const contextText =
+            `<retrieved-context>\n` +
+            `The following Pathfinder 2e rule data was retrieved as relevant to the user's question:\n\n` +
+            contextParts.join("\n\n") +
+            `\n</retrieved-context>`;
+
+        // Step 5: Build sources list
+        /** @type {RagSource[]} */
+        const sources = topResults.map((entry) => ({
+            name: entry.chunk.ruleItemName,
+            type: entry.chunk.ruleItemType,
+            score: entry.score,
+        }));
+
+        return { contextText, sources };
+    } catch {
+        // Never throw — degrade gracefully
+        return { contextText: "", sources: [] };
+    }
+}

--- a/server/utils/rag-query.test.js
+++ b/server/utils/rag-query.test.js
@@ -50,7 +50,7 @@ describe("rag-query", () => {
             const embedding = await createSingleEmbedding(
                 "test prompt",
                 "fake-key",
-                "text-embedding-004",
+                "gemini-embedding-001",
             );
 
             expect(Array.isArray(embedding)).toBe(true);

--- a/server/utils/rag-query.test.js
+++ b/server/utils/rag-query.test.js
@@ -1,0 +1,214 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { packEmbedding } from "../../scripts/create-vector-db.js";
+import { createSingleEmbedding, queryRagContext } from "./rag-query.js";
+
+/**
+ * @param {Database} db
+ * @param {{ id: string, ruleItemId: string, ruleItemName: string, ruleItemType: string, compendiumSource?: string | null, chunkIndex: number, text: string, embedding?: number[] | null }} chunk
+ */
+function insertChunk(db, chunk) {
+    const embeddingBlob = chunk.embedding ? packEmbedding(chunk.embedding) : null;
+    db.run(
+        "INSERT OR REPLACE INTO vector_chunks (id, rule_item_id, rule_item_name, rule_item_type, compendium_source, chunk_index, text, embedding, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            chunk.id,
+            chunk.ruleItemId,
+            chunk.ruleItemName,
+            chunk.ruleItemType,
+            chunk.compendiumSource ?? null,
+            chunk.chunkIndex,
+            chunk.text,
+            embeddingBlob,
+            new Date().toISOString(),
+        ],
+    );
+}
+
+describe("rag-query", () => {
+    const originalApiKey = process.env.GOOGLE_AI_API_KEY;
+    const originalMockAi = process.env.MOCK_GOOGLE_AI;
+
+    afterEach(() => {
+        if (originalApiKey !== undefined) {
+            process.env.GOOGLE_AI_API_KEY = originalApiKey;
+        } else {
+            delete process.env.GOOGLE_AI_API_KEY;
+        }
+        if (originalMockAi !== undefined) {
+            process.env.MOCK_GOOGLE_AI = originalMockAi;
+        } else {
+            delete process.env.MOCK_GOOGLE_AI;
+        }
+    });
+
+    describe("createSingleEmbedding", () => {
+        it("wraps single text into array and returns first result", async () => {
+            process.env.MOCK_GOOGLE_AI = "1";
+
+            const embedding = await createSingleEmbedding(
+                "test prompt",
+                "fake-key",
+                "text-embedding-004",
+            );
+
+            expect(Array.isArray(embedding)).toBe(true);
+            expect(embedding.length).toBeGreaterThan(0);
+        });
+    });
+
+    describe("queryRagContext", () => {
+        /** @type {Database} */
+        let vdb;
+
+        beforeEach(() => {
+            vdb = new Database(":memory:");
+            vdb.exec("PRAGMA journal_mode=WAL");
+            vdb.exec(`
+                CREATE TABLE IF NOT EXISTS vector_chunks (
+                    id TEXT PRIMARY KEY,
+                    rule_item_id TEXT NOT NULL,
+                    rule_item_name TEXT NOT NULL,
+                    rule_item_type TEXT NOT NULL,
+                    compendium_source TEXT,
+                    chunk_index INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    embedding BLOB,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+            `);
+        });
+
+        afterEach(() => {
+            if (vdb) {
+                vdb.close();
+            }
+        });
+
+        it("returns empty context when no vector DB provided", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            process.env.MOCK_GOOGLE_AI = "1";
+
+            const result = await queryRagContext("What is Fireball?", {
+                vectorDb: null,
+            });
+
+            expect(result.contextText).toBe("");
+            expect(result.sources).toEqual([]);
+        });
+
+        it("returns empty context when no API key is set", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            const result = await queryRagContext("What is Fireball?", {
+                vectorDb: vdb,
+            });
+
+            expect(result.contextText).toBe("");
+            expect(result.sources).toEqual([]);
+        });
+
+        it("returns formatted context with matched chunks", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            process.env.MOCK_GOOGLE_AI = "1";
+
+            // Insert a chunk with embedding that will match
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                compendiumSource: "Pathfinder Core Rulebook",
+                chunkIndex: 0,
+                text: "Spell: Fireball (Rank 3). Traditions: arcane, primal. Cast: two actions.",
+                embedding: Array(768)
+                    .fill(0)
+                    .map((_, i) => (i === 0 ? 1 : 0)), // [1,0,0,...,0]
+            });
+
+            const result = await queryRagContext("What is Fireball?", {
+                vectorDb: vdb,
+                topN: 5,
+                threshold: 0.1,
+            });
+
+            expect(result.contextText).toContain("retrieved-context");
+            expect(result.contextText).toContain("Fireball");
+            expect(result.sources).toHaveLength(1);
+            expect(result.sources[0].name).toBe("Fireball");
+            expect(result.sources[0].type).toBe("spell");
+            expect(result.sources[0].score).toBeGreaterThan(0);
+        });
+
+        it("deduplicates by rule item ID keeping highest score", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            process.env.MOCK_GOOGLE_AI = "1";
+
+            // Two chunks from the same rule item, one more similar
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Fireball description",
+                embedding: Array(768)
+                    .fill(0)
+                    .map((_, i) => (i === 0 ? 0.9 : 0)),
+            });
+            insertChunk(vdb, {
+                id: "c2",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 1,
+                text: "Fireball heightened effects",
+                embedding: Array(768)
+                    .fill(0)
+                    .map((_, i) => (i === 0 ? 0.5 : 0)),
+            });
+
+            const result = await queryRagContext("Fireball?", {
+                vectorDb: vdb,
+                topN: 5,
+                threshold: 0.1,
+            });
+
+            // Should deduplicate to just 1 source for ri1
+            expect(result.sources).toHaveLength(1);
+            expect(result.sources[0].name).toBe("Fireball");
+        });
+
+        it("mock mode generates deterministic fake embedding without API call", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            process.env.MOCK_GOOGLE_AI = "1";
+
+            // Just verify it doesn't throw and produces results
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Test",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Test text",
+                embedding: Array(768)
+                    .fill(0)
+                    .map((_, i) => (i === 0 ? 1 : 0)),
+            });
+
+            // Should not throw - mock mode uses fake embedding
+            const result = await queryRagContext("anything", {
+                vectorDb: vdb,
+                topN: 5,
+                threshold: 0.0,
+            });
+
+            // Mock embedding is deterministic but may or may not match the test embedding
+            // Just verify structure is correct
+            expect(result).toHaveProperty("contextText");
+            expect(result).toHaveProperty("sources");
+            expect(Array.isArray(result.sources)).toBe(true);
+        });
+    });
+});

--- a/server/utils/vector-store.js
+++ b/server/utils/vector-store.js
@@ -1,0 +1,172 @@
+import { Database } from "bun:sqlite";
+import { existsSync } from "fs";
+
+import { unpackEmbedding } from "../../scripts/create-vector-db.js";
+
+/** @type {Database | null | undefined} */
+let cachedVectorDb = undefined;
+
+/**
+ * Opens the vector database. Returns null gracefully if file doesn't exist.
+ * Caches singleton to avoid repeated file-exists checks.
+ * @param {string} [dbPath] - Path to the vector DB file. Defaults to env VECTOR_DB_PATH or "data/vectors.sqlite".
+ * @returns {Database | null}
+ */
+export function openVectorDb(dbPath) {
+    if (cachedVectorDb !== undefined) {
+        return cachedVectorDb;
+    }
+
+    const path = dbPath || process.env.VECTOR_DB_PATH || "data/vectors.sqlite";
+
+    // Allow :memory: for testing
+    if (path === ":memory:") {
+        const vdb = new Database(path);
+        vdb.exec("PRAGMA journal_mode=WAL");
+        vdb.exec(CREATE_VECTOR_TABLE_SQL);
+        cachedVectorDb = vdb;
+        return vdb;
+    }
+
+    if (!existsSync(path)) {
+        cachedVectorDb = null;
+        return null;
+    }
+
+    const vdb = new Database(path);
+    vdb.exec("PRAGMA journal_mode=WAL");
+    cachedVectorDb = vdb;
+    return vdb;
+}
+
+/**
+ * Resets the cached vector DB singleton. Useful for testing.
+ */
+export function resetVectorDbCache() {
+    cachedVectorDb = undefined;
+}
+
+/** SQL to create the vector_chunks table. */
+const CREATE_VECTOR_TABLE_SQL = `
+CREATE TABLE IF NOT EXISTS vector_chunks (
+    id TEXT PRIMARY KEY,
+    rule_item_id TEXT NOT NULL,
+    rule_item_name TEXT NOT NULL,
+    rule_item_type TEXT NOT NULL,
+    compendium_source TEXT,
+    chunk_index INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    embedding BLOB,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_vector_chunks_rule_item ON vector_chunks(rule_item_id);
+CREATE INDEX IF NOT EXISTS idx_vector_chunks_type ON vector_chunks(rule_item_type);
+`;
+
+/**
+ * @typedef {{ id: string, ruleItemId: string, ruleItemName: string, ruleItemType: string, compendiumSource: string | null, text: string, embedding: number[] }} ChunkWithEmbedding
+ */
+
+/**
+ * Gets all chunk embeddings from the vector DB, unpacking BLOBs.
+ * Filters out rows with null embeddings.
+ * @param {Database} vdb
+ * @returns {ChunkWithEmbedding[]}
+ */
+export function getAllChunkEmbeddings(vdb) {
+    const rows = vdb
+        .query(
+            "SELECT id, rule_item_id, rule_item_name, rule_item_type, compendium_source, text, embedding FROM vector_chunks",
+        )
+        .all();
+
+    /** @type {ChunkWithEmbedding[]} */
+    const result = [];
+    for (const row of rows) {
+        if (!row.embedding) {
+            continue;
+        }
+        /** @type {ChunkWithEmbedding} */
+        const chunk = {
+            id: String(row.id),
+            ruleItemId: String(row.rule_item_id),
+            ruleItemName: String(row.rule_item_name),
+            ruleItemType: String(row.rule_item_type),
+            compendiumSource: row.compendium_source ? String(row.compendium_source) : null,
+            text: String(row.text),
+            embedding: unpackEmbedding(/** @type {Buffer} */ (row.embedding)),
+        };
+        result.push(chunk);
+    }
+    return result;
+}
+
+/**
+ * Computes cosine similarity between two vectors.
+ * Returns 0 for zero-length vectors.
+ * @param {number[]} vecA
+ * @param {number[]} vecB
+ * @returns {number}
+ */
+export function cosineSimilarity(vecA, vecB) {
+    const len = Math.min(vecA.length, vecB.length);
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < len; i++) {
+        dotProduct += vecA[i] * vecB[i];
+        normA += vecA[i] * vecA[i];
+        normB += vecB[i] * vecB[i];
+    }
+
+    if (normA === 0 || normB === 0) {
+        return 0;
+    }
+
+    return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+/**
+ * Searches the vector DB for chunks similar to the query embedding.
+ * @param {Database} vdb
+ * @param {number[]} queryEmbedding
+ * @param {number} topN - Maximum number of results to return.
+ * @param {number} threshold - Minimum cosine similarity score.
+ * @returns {Array<{ chunk: ChunkWithEmbedding, score: number }>}
+ */
+export function searchVectorDb(vdb, queryEmbedding, topN, threshold) {
+    const allChunks = getAllChunkEmbeddings(vdb);
+
+    /** @type {Array<{ chunk: ChunkWithEmbedding, score: number }>} */
+    const scored = [];
+    for (const chunk of allChunks) {
+        const score = cosineSimilarity(queryEmbedding, chunk.embedding);
+        if (score >= threshold) {
+            scored.push({ chunk, score });
+        }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, topN);
+}
+
+/**
+ * Gets all chunks for a specific rule item ID (for parent enrichment).
+ * @param {Database} vdb
+ * @param {string} ruleItemId
+ * @returns {Array<{ id: string, text: string, chunkIndex: number }>}
+ */
+export function getChunksByRuleItemId(vdb, ruleItemId) {
+    const rows = vdb
+        .query(
+            "SELECT id, text, chunk_index FROM vector_chunks WHERE rule_item_id = ? ORDER BY chunk_index",
+        )
+        .all(ruleItemId);
+
+    return rows.map((row) => ({
+        id: String(row.id),
+        text: String(row.text),
+        chunkIndex: Number(row.chunk_index),
+    }));
+}

--- a/server/utils/vector-store.test.js
+++ b/server/utils/vector-store.test.js
@@ -1,0 +1,266 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { packEmbedding } from "../../scripts/create-vector-db.js";
+import {
+    cosineSimilarity,
+    getAllChunkEmbeddings,
+    getChunksByRuleItemId,
+    openVectorDb,
+    resetVectorDbCache,
+    searchVectorDb,
+} from "./vector-store.js";
+
+/**
+ * @param {Database} db
+ * @param {{ id: string, ruleItemId: string, ruleItemName: string, ruleItemType: string, compendiumSource?: string | null, chunkIndex: number, text: string, embedding?: number[] | null }} chunk
+ */
+function insertChunk(db, chunk) {
+    const embeddingBlob = chunk.embedding ? packEmbedding(chunk.embedding) : null;
+    db.run(
+        "INSERT OR REPLACE INTO vector_chunks (id, rule_item_id, rule_item_name, rule_item_type, compendium_source, chunk_index, text, embedding, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            chunk.id,
+            chunk.ruleItemId,
+            chunk.ruleItemName,
+            chunk.ruleItemType,
+            chunk.compendiumSource ?? null,
+            chunk.chunkIndex,
+            chunk.text,
+            embeddingBlob,
+            new Date().toISOString(),
+        ],
+    );
+}
+
+describe("vector-store", () => {
+    describe("cosineSimilarity", () => {
+        it("returns 1.0 for identical vectors", () => {
+            const vec = [1, 2, 3, 4];
+            expect(cosineSimilarity(vec, vec)).toBeCloseTo(1.0);
+        });
+
+        it("returns 0.0 for orthogonal vectors", () => {
+            const vecA = [1, 0, 0];
+            const vecB = [0, 1, 0];
+            expect(cosineSimilarity(vecA, vecB)).toBeCloseTo(0.0);
+        });
+
+        it("returns -1.0 for opposite vectors", () => {
+            const vecA = [1, 2, 3];
+            const vecB = [-1, -2, -3];
+            expect(cosineSimilarity(vecA, vecB)).toBeCloseTo(-1.0);
+        });
+
+        it("returns 0.0 for zero vectors", () => {
+            expect(cosineSimilarity([0, 0, 0], [1, 2, 3])).toBe(0.0);
+            expect(cosineSimilarity([1, 2, 3], [0, 0, 0])).toBe(0.0);
+        });
+
+        it("computes correct similarity for arbitrary vectors", () => {
+            // [1,2,3] . [4,5,6] = 4+10+18 = 32
+            // normA = sqrt(14), normB = sqrt(77) = sqrt(14*77) = sqrt(1078)
+            // sim = 32/sqrt(1078) ≈ 0.9746
+            const result = cosineSimilarity([1, 2, 3], [4, 5, 6]);
+            expect(result).toBeCloseTo(0.9746, 3);
+        });
+    });
+
+    describe("openVectorDb", () => {
+        beforeEach(() => {
+            resetVectorDbCache();
+        });
+
+        afterEach(() => {
+            resetVectorDbCache();
+        });
+
+        it("returns null for non-existent path", () => {
+            const result = openVectorDb("/tmp/nonexistent_vdb_test.sqlite");
+            expect(result).toBeNull();
+        });
+
+        it("returns DB for valid in-memory path", () => {
+            const result = openVectorDb(":memory:");
+            expect(result).not.toBeNull();
+            if (result) {
+                result.close();
+            }
+        });
+    });
+
+    describe("getAllChunkEmbeddings and searchVectorDb", () => {
+        /** @type {Database} */
+        let vdb;
+
+        beforeEach(() => {
+            vdb = new Database(":memory:");
+            vdb.exec("PRAGMA journal_mode=WAL");
+            vdb.exec(`
+                CREATE TABLE IF NOT EXISTS vector_chunks (
+                    id TEXT PRIMARY KEY,
+                    rule_item_id TEXT NOT NULL,
+                    rule_item_name TEXT NOT NULL,
+                    rule_item_type TEXT NOT NULL,
+                    compendium_source TEXT,
+                    chunk_index INTEGER NOT NULL,
+                    text TEXT NOT NULL,
+                    embedding BLOB,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                );
+            `);
+        });
+
+        afterEach(() => {
+            if (vdb) {
+                vdb.close();
+            }
+        });
+
+        it("getAllChunkEmbeddings unpacks BLOBs and skips null embeddings", () => {
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                compendiumSource: "AoN",
+                chunkIndex: 0,
+                text: "Fireball spell text",
+                embedding: [0.1, 0.2, 0.3],
+            });
+            insertChunk(vdb, {
+                id: "c2",
+                ruleItemId: "ri2",
+                ruleItemName: "Shield",
+                ruleItemType: "spell",
+                compendiumSource: null,
+                chunkIndex: 0,
+                text: "Shield spell text",
+                embedding: null,
+            });
+
+            const chunks = getAllChunkEmbeddings(vdb);
+            expect(chunks).toHaveLength(1);
+            expect(chunks[0].id).toBe("c1");
+            expect(chunks[0].ruleItemName).toBe("Fireball");
+            expect(chunks[0].embedding).toHaveLength(3);
+            expect(chunks[0].embedding[0]).toBeCloseTo(0.1);
+        });
+
+        it("searchVectorDb returns correct top-N sorted by score", () => {
+            const queryEmb = [1, 0, 0]; // Query vector pointing along x-axis
+
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Fireball text",
+                embedding: [0.9, 0.1, 0], // High similarity to query
+            });
+            insertChunk(vdb, {
+                id: "c2",
+                ruleItemId: "ri2",
+                ruleItemName: "Shield",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Shield text",
+                embedding: [0.1, 0.9, 0], // Low similarity to query
+            });
+            insertChunk(vdb, {
+                id: "c3",
+                ruleItemId: "ri3",
+                ruleItemName: "Magic Missile",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Magic Missile text",
+                embedding: [0.8, 0.2, 0], // Medium similarity
+            });
+
+            const results = searchVectorDb(vdb, queryEmb, 2, 0.0);
+            expect(results).toHaveLength(2);
+            expect(results[0].chunk.ruleItemName).toBe("Fireball");
+            expect(results[0].score).toBeGreaterThan(results[1].score);
+            expect(results[1].chunk.ruleItemName).toBe("Magic Missile");
+        });
+
+        it("searchVectorDb filters by threshold", () => {
+            const queryEmb = [1, 0, 0];
+
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Fireball text",
+                embedding: [0.95, 0.05, 0], // ~0.998 similarity
+            });
+            insertChunk(vdb, {
+                id: "c2",
+                ruleItemId: "ri2",
+                ruleItemName: "Shield",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Shield text",
+                embedding: [0.1, 0.9, 0], // ~0.11 similarity
+            });
+
+            const results = searchVectorDb(vdb, queryEmb, 5, 0.5);
+            expect(results).toHaveLength(1);
+            expect(results[0].chunk.ruleItemName).toBe("Fireball");
+        });
+
+        it("getChunksByRuleItemId returns all chunks for a given rule item", () => {
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Fireball part 1",
+                embedding: [0.1],
+            });
+            insertChunk(vdb, {
+                id: "c2",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                chunkIndex: 1,
+                text: "Fireball part 2",
+                embedding: [0.2],
+            });
+            insertChunk(vdb, {
+                id: "c3",
+                ruleItemId: "ri2",
+                ruleItemName: "Shield",
+                ruleItemType: "spell",
+                chunkIndex: 0,
+                text: "Shield text",
+                embedding: [0.3],
+            });
+
+            const chunks = getChunksByRuleItemId(vdb, "ri1");
+            expect(chunks).toHaveLength(2);
+            expect(chunks.map((c) => c.id).sort()).toEqual(["c1", "c2"]);
+        });
+
+        it("searchVectorDb includes compendiumSource in results", () => {
+            insertChunk(vdb, {
+                id: "c1",
+                ruleItemId: "ri1",
+                ruleItemName: "Fireball",
+                ruleItemType: "spell",
+                compendiumSource: "Pathfinder Core Rulebook",
+                chunkIndex: 0,
+                text: "Fireball text",
+                embedding: [1, 0, 0],
+            });
+
+            const results = searchVectorDb(vdb, [1, 0, 0], 1, 0.0);
+            expect(results).toHaveLength(1);
+            expect(results[0].chunk.compendiumSource).toBe("Pathfinder Core Rulebook");
+        });
+    });
+});

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -2,6 +2,15 @@
  * Constants shared between server and client.
  */
 
+/** RAG pipeline configuration defaults */
+export const RAG_CONFIG = {
+    EMBEDDING_MODEL: "text-embedding-004",
+    LLM_MODEL: "gemini-2.0-flash-lite",
+    TOP_N: 5,
+    SIMILARITY_THRESHOLD: 0.3,
+    VECTOR_DB_PATH: "data/vectors.sqlite",
+};
+
 /** Deterministic UUIDs for seed data — stable across restarts, usable in tests */
 export const SEED_IDS = {
     USER_DEFAULT: "00000000-0000-4000-8000-000000000001",

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -4,8 +4,8 @@
 
 /** RAG pipeline configuration defaults */
 export const RAG_CONFIG = {
-    EMBEDDING_MODEL: "text-embedding-004",
-    LLM_MODEL: "gemini-2.0-flash-lite",
+    EMBEDDING_MODEL: "gemini-embedding-001",
+    LLM_MODEL: "gemini-3.1-flash-lite",
     TOP_N: 5,
     SIMILARITY_THRESHOLD: 0.3,
     VECTOR_DB_PATH: "data/vectors.sqlite",

--- a/shared/hono-env.js
+++ b/shared/hono-env.js
@@ -1,4 +1,4 @@
 /**
- * @typedef {{ Variables: { db: import("bun:sqlite").Database, userId: string, sessionId: string } }} AppEnv
+ * @typedef {{ Variables: { db: import("bun:sqlite").Database, userId: string, sessionId: string, vectorDb: import("bun:sqlite").Database | null } }} AppEnv
  */
 export {};

--- a/shared/schemas.js
+++ b/shared/schemas.js
@@ -146,6 +146,16 @@ const ensureTestUserSchema = z.object({
     mode: z.enum(["gm", "player"]),
 });
 
+const vectorChunkResultSchema = z.object({
+    id: z.string(),
+    ruleItemId: z.string(),
+    ruleItemName: z.string(),
+    ruleItemType: z.string(),
+    compendiumSource: z.string().nullable().optional(),
+    text: z.string(),
+    score: z.number(),
+});
+
 export {
     uuidSchema,
     conversationIdSchema,
@@ -166,4 +176,5 @@ export {
     createMessageSchema,
     updateUserSchema,
     ensureTestUserSchema,
+    vectorChunkResultSchema,
 };

--- a/shared/types.js
+++ b/shared/types.js
@@ -79,6 +79,10 @@
 
 /** @typedef {{ id: string, ruleItemId: string, ruleItemName: string, ruleItemType: string, compendiumSource: string | undefined, chunkIndex: number, text: string, embedding?: number[] }} VectorChunk */
 
+/** @typedef {{ name: string, type: string, score: number }} RagSource */
+
+/** @typedef {{ contextText: string, sources: Array<RagSource> }} RagContext */
+
 /** @typedef {{ inserted: number, updated: number, skipped: number, errors: number }} ImportResult */
 
 /** @typedef {{ id: string, role: "user", content: string, blocks?: never, mode: Mode, conversationId: string, createdAt: string }} UserMessage */


### PR DESCRIPTION
## Summary

- Add vector DB cosine similarity search (`vector-store.js`) against stored embeddings in `data/vectors.sqlite`
- Add RAG pipeline (`rag-query.js`): embed prompt → search → deduplicate by parent → format context
- Add Gemini LLM client (`llm-client.js`): streams responses with RAG-augmented system prompt
- Integrate into SSE message stream in `messages.js`, replacing mock responses with real rule data retrieval
- Graceful fallback: no API key or no vector DB → falls back to existing mock behavior with no breaking changes

## Test plan

- [x] 444 unit tests pass (12 new tests across 3 new test files)
- [x] Typecheck clean (`tsgo`)
- [x] Lint clean (`oxlint`)
- [x] Format clean (`oxfmt`)
- [x] Existing tests unchanged — mock path still active when `GOOGLE_AI_API_KEY` unset

Closes #80