### PR TITLE
fix: make rule_items constraint migration idempotent

### DIFF
--- a/server/db/migrate.js
+++ b/server/db/migrate.js
@@ -74,6 +74,8 @@ function _migrateRuleItemsConstraint(database) {
         return;
     }
 
+    // If a previous migration was interrupted, rule_items_old may still exist
+    database.run("DROP TABLE IF EXISTS rule_items_old");
     database.run("ALTER TABLE rule_items RENAME TO rule_items_old");
     database.run(`
         CREATE TABLE rule_items (


### PR DESCRIPTION
## Summary

- Fixes a regression where the `rule_items` constraint migration crashes on startup in production when a previous migration was interrupted, leaving `rule_items_old` orphaned in the persistent Docker volume
- Adds `DROP TABLE IF EXISTS rule_items_old` before the rename step to make the migration idempotent

## Root cause

The `deploy-main.yml` workflow mounts a named Docker volume (`pathfinder_db`) at `/app/data`. If the `_migrateRuleItemsConstraint` migration is interrupted (e.g. container killed mid-deploy), the `rule_items_old` table persists in the volume. On the next startup, `ALTER TABLE rule_items RENAME TO rule_items_old` fails because the `_old` table already exists — and there was no guard for this case.