### PR TITLE
feat: integrate conversation history into LLM calls

### DIFF
--- a/server/db/migrate.js
+++ b/server/db/migrate.js
@@ -51,6 +51,15 @@ export function migrateDb(database) {
     // Migration: monster → creature type rename
     database.run("UPDATE rule_items SET type = 'creature' WHERE type = 'monster'");
 
+    const convColumns = database
+        .query("PRAGMA table_info(conversations)")
+        .all()
+        .map((col) => col.name);
+
+    if (!convColumns.includes("compacted_summary")) {
+        database.run("ALTER TABLE conversations ADD COLUMN compacted_summary TEXT");
+    }
+
     // Clean up expired challenges (older than 5 minutes)
     database.run("DELETE FROM challenges WHERE created_at < datetime('now', '-5 minutes')");
 }

--- a/server/db/queries.js
+++ b/server/db/queries.js
@@ -9,12 +9,14 @@ const ConversationSchema = z
         title: z.string(),
         user_id: z.string(),
         created_at: z.string(),
+        compacted_summary: z.string().nullable().optional(),
     })
     .transform((row) => ({
         id: row.id,
         title: row.title,
         userId: row.user_id,
         createdAt: row.created_at,
+        compactedSummary: row.compacted_summary ?? null,
     }));
 
 const ConversationListSchema = z.array(ConversationSchema);
@@ -168,7 +170,9 @@ export function getAllConversations(database = db) {
 export function getConversationById(database, id) {
     /** @type {unknown} */
     const row = database
-        .query("SELECT id, title, user_id, created_at FROM conversations WHERE id = ?")
+        .query(
+            "SELECT id, title, user_id, created_at, compacted_summary FROM conversations WHERE id = ?",
+        )
         .get(id);
     if (!row) {
         return null;
@@ -832,4 +836,17 @@ export function getRuleItemsByTypeAndNames(database, type, names) {
         map.set(row.name, row);
     }
     return map;
+}
+
+/**
+ * Updates the compacted summary for a conversation.
+ * @param {import("bun:sqlite").Database} database - The database instance
+ * @param {string} conversationId - The conversation ID
+ * @param {string} summary - The summary text
+ */
+export function updateCompactedSummary(database, conversationId, summary) {
+    database.run("UPDATE conversations SET compacted_summary = ? WHERE id = ?", [
+        summary,
+        conversationId,
+    ]);
 }

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -3,7 +3,9 @@ import { Hono } from "hono";
 
 import { createMessageSchema } from "../../shared/schemas.js";
 import * as queries from "../db/queries.js";
+import { compactConversation } from "../utils/compaction.js";
 import { getDb, getUserId, getVectorDb } from "../utils/context.js";
+import { formatConversationForLlm } from "../utils/conversation-history.js";
 import { resolveLocalizeRefs, resolveUuidRefs, loadLocalizations } from "../utils/foundry-refs.js";
 import { RetryableError, getLlmResponse } from "../utils/llm-client.js";
 import { queryRagContext } from "../utils/rag-query.js";
@@ -264,14 +266,14 @@ function resolveConversation(convId, db, userId) {
  * Calls getLlmResponse with automatic retries on RetryableError.
  * Notifies the stream of retry events via `notify`; returns false from notify to abort retrying
  * (signals client disconnection).
- * @param {{ content: string, contextText: string, mode: string, userId: string }} params
+ * @param {{ contents: Array<{role: string, parts: Array<{text: string}>}>, contextText: string, mode: string, userId: string }} params
  * @param {(event: object) => boolean} notify
  * @returns {Promise<import("../../shared/types.js").MessageBlock[] | undefined>}
  */
-async function getLlmResponseWithRetry({ content, contextText, mode, userId }, notify) {
+async function getLlmResponseWithRetry({ contents, contextText, mode, userId }, notify) {
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
         try {
-            return await getLlmResponse(content, contextText, mode, userId);
+            return await getLlmResponse(contents, contextText, mode, userId);
         } catch (error) {
             if (!(error instanceof RetryableError)) {
                 throw error;
@@ -339,9 +341,17 @@ async function runResponseStream(controller, ctx) {
             threshold: 0.3,
         });
 
+        const llmContents = formatConversationForLlm(db, actualConvId);
+
+        try {
+            await compactConversation(db, actualConvId, llmContents);
+        } catch {
+            // Compaction failure is non-fatal
+        }
+
         const llmBlocks = await getLlmResponseWithRetry(
             {
-                content: data.content,
+                contents: llmContents,
                 contextText: ragContext.contextText,
                 mode: data.mode,
                 userId,

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -5,7 +5,7 @@ import { createMessageSchema } from "../../shared/schemas.js";
 import * as queries from "../db/queries.js";
 import { compactConversation } from "../utils/compaction.js";
 import { getDb, getUserId, getVectorDb } from "../utils/context.js";
-import { formatConversationForLlm } from "../utils/conversation-history.js";
+import { formatConversationForLlm, shouldCompact } from "../utils/conversation-history.js";
 import { resolveLocalizeRefs, resolveUuidRefs, loadLocalizations } from "../utils/foundry-refs.js";
 import { RetryableError, getLlmResponse } from "../utils/llm-client.js";
 import { queryRagContext } from "../utils/rag-query.js";
@@ -345,8 +345,18 @@ async function runResponseStream(controller, ctx) {
 
         try {
             await compactConversation(db, actualConvId, llmContents);
-        } catch {
-            // Compaction failure is non-fatal
+        } catch (compactionError) {
+            // oxlint-disable-next-line no-console
+            console.error("Compaction failed:", compactionError);
+            if (shouldCompact(llmContents)) {
+                tryEnqueue(controller, {
+                    type: "compactionWarning",
+                    data: {
+                        message:
+                            "This conversation is getting long. If the AI can't respond, try starting a new conversation.",
+                    },
+                });
+            }
         }
 
         const llmBlocks = await getLlmResponseWithRetry(

--- a/server/utils/compaction.js
+++ b/server/utils/compaction.js
@@ -5,7 +5,8 @@ import { callGeminiForSummarization } from "./llm-client.js";
 
 /**
  * Orchestrate summarization and storage of old conversation messages.
- * Returns the summary text, or null if compaction was not needed or failed.
+ * Returns the summary text, or null if compaction was not needed.
+ * Throws if summarization API call fails.
  * @param {import("bun:sqlite").Database} db
  * @param {string} conversationId
  * @param {Array<{ role: string, parts: Array<{ text: string }> }>} contents
@@ -32,13 +33,9 @@ export async function compactConversation(db, conversationId, contents, threshol
         .map((turn) => `${turn.role}: ${turn.parts.map((p) => p.text).join("\n")}`)
         .join("\n\n");
 
-    try {
-        const summary = await callGeminiForSummarization(messagesText);
-        if (summary) {
-            updateCompactedSummary(db, conversationId, summary);
-        }
-        return summary;
-    } catch {
-        return null;
+    const summary = await callGeminiForSummarization(messagesText);
+    if (summary) {
+        updateCompactedSummary(db, conversationId, summary);
     }
+    return summary;
 }

--- a/server/utils/compaction.js
+++ b/server/utils/compaction.js
@@ -1,0 +1,44 @@
+import { CONVERSATION_CONFIG } from "../../shared/constants.js";
+import { getConversationById, updateCompactedSummary } from "../db/queries.js";
+import { shouldCompact } from "./conversation-history.js";
+import { callGeminiForSummarization } from "./llm-client.js";
+
+/**
+ * Orchestrate summarization and storage of old conversation messages.
+ * Returns the summary text, or null if compaction was not needed or failed.
+ * @param {import("bun:sqlite").Database} db
+ * @param {string} conversationId
+ * @param {Array<{ role: string, parts: Array<{ text: string }> }>} contents
+ * @param {number} [threshold]
+ * @returns {Promise<string | null>}
+ */
+export async function compactConversation(db, conversationId, contents, threshold) {
+    const conversation = getConversationById(db, conversationId);
+    if (conversation?.compactedSummary) {
+        return null;
+    }
+
+    if (!shouldCompact(contents, threshold)) {
+        return null;
+    }
+
+    const keepRecent = CONVERSATION_CONFIG.COMPACTION_KEEP_RECENT_TURNS * 2;
+    if (contents.length <= keepRecent) {
+        return null;
+    }
+
+    const oldTurns = contents.slice(0, -keepRecent);
+    const messagesText = oldTurns
+        .map((turn) => `${turn.role}: ${turn.parts.map((p) => p.text).join("\n")}`)
+        .join("\n\n");
+
+    try {
+        const summary = await callGeminiForSummarization(messagesText);
+        if (summary) {
+            updateCompactedSummary(db, conversationId, summary);
+        }
+        return summary;
+    } catch {
+        return null;
+    }
+}

--- a/server/utils/compaction.test.js
+++ b/server/utils/compaction.test.js
@@ -88,7 +88,7 @@ describe("compaction", () => {
             expect(conv?.compactedSummary).toBe(summaryText);
         });
 
-        it("returns null on summarization failure", async () => {
+        it("throws on summarization failure instead of returning null", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
 
             globalThis.fetch = /** @type {typeof fetch} */ (
@@ -108,9 +108,9 @@ describe("compaction", () => {
                 parts: [{ text: `x`.repeat(1000) }],
             }));
 
-            const result = await compactConversation(db, convId, oldTurns, 100);
-
-            expect(result).toBeNull();
+            expect(compactConversation(db, convId, oldTurns, 100)).rejects.toThrow(
+                "Gemini summarization API error",
+            );
 
             const conv = getConversationById(db, convId);
             expect(conv?.compactedSummary).toBeNull();

--- a/server/utils/compaction.test.js
+++ b/server/utils/compaction.test.js
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+import { createDb } from "../db/database.js";
+import { createConversation, createUser, getConversationById } from "../db/queries.js";
+import { compactConversation } from "./compaction.js";
+
+/** @param {string} text */
+function geminiSummaryResponse(text) {
+    return {
+        ok: true,
+        json: () =>
+            Promise.resolve({
+                candidates: [
+                    {
+                        content: {
+                            parts: [{ text }],
+                        },
+                    },
+                ],
+            }),
+    };
+}
+
+describe("compaction", () => {
+    /** @type {ReturnType<typeof createDb>} */
+    let db;
+    /** @type {string} */
+    let convId;
+
+    beforeEach(() => {
+        db = createDb(":memory:");
+        const user = createUser(db, {
+            name: "Test User",
+            initials: "TU",
+            subtitle: "Test",
+            mode: "player",
+            email: null,
+            isTestUser: false,
+        });
+        const conv = createConversation(db, { title: "Test Chat", userId: user.id });
+        convId = conv.id;
+    });
+
+    afterEach(() => {
+        if (db) {
+            db.close();
+        }
+        mock.restore();
+        delete process.env.GOOGLE_AI_API_KEY;
+    });
+
+    describe("compactConversation", () => {
+        it("returns null when contents are below threshold", async () => {
+            const contents = [{ role: "user", parts: [{ text: "short message" }] }];
+            const result = await compactConversation(db, convId, contents);
+            expect(result).toBeNull();
+        });
+
+        it("returns null when contents are within keep-recent window", async () => {
+            const contents = Array.from({ length: 4 }, (_, i) => ({
+                role: i % 2 === 0 ? "user" : "model",
+                parts: [{ text: `Turn ${i}` }],
+            }));
+            const result = await compactConversation(db, convId, contents, 10);
+            expect(result).toBeNull();
+        });
+
+        it("calls summarization and stores summary when threshold exceeded", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const summaryText = "This is a summary of the conversation.";
+
+            globalThis.fetch = /** @type {typeof fetch} */ (
+                /** @type {unknown} */ (
+                    mock(() => Promise.resolve(geminiSummaryResponse(summaryText)))
+                )
+            );
+
+            const oldTurns = Array.from({ length: 30 }, (_, i) => ({
+                role: i % 2 === 0 ? "user" : "model",
+                parts: [{ text: `x`.repeat(1000) }],
+            }));
+
+            const result = await compactConversation(db, convId, oldTurns, 100);
+
+            expect(result).toBe(summaryText);
+
+            const conv = getConversationById(db, convId);
+            expect(conv?.compactedSummary).toBe(summaryText);
+        });
+
+        it("returns null on summarization failure", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            globalThis.fetch = /** @type {typeof fetch} */ (
+                /** @type {unknown} */ (
+                    mock(() =>
+                        Promise.resolve({
+                            ok: false,
+                            status: 500,
+                            text: () => Promise.resolve("Server Error"),
+                        }),
+                    )
+                )
+            );
+
+            const oldTurns = Array.from({ length: 30 }, (_, i) => ({
+                role: i % 2 === 0 ? "user" : "model",
+                parts: [{ text: `x`.repeat(1000) }],
+            }));
+
+            const result = await compactConversation(db, convId, oldTurns, 100);
+
+            expect(result).toBeNull();
+
+            const conv = getConversationById(db, convId);
+            expect(conv?.compactedSummary).toBeNull();
+        });
+
+        it("skips summarization when compacted summary already exists", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() =>
+                Promise.resolve(geminiSummaryResponse("should not be called")),
+            );
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            db.run("UPDATE conversations SET compacted_summary = ? WHERE id = ?", [
+                "Existing summary.",
+                convId,
+            ]);
+
+            const oldTurns = Array.from({ length: 30 }, (_, i) => ({
+                role: i % 2 === 0 ? "user" : "model",
+                parts: [{ text: `x`.repeat(1000) }],
+            }));
+
+            const result = await compactConversation(db, convId, oldTurns, 100);
+
+            expect(result).toBeNull();
+            expect(fetchMock).not.toHaveBeenCalled();
+
+            const conv = getConversationById(db, convId);
+            expect(conv?.compactedSummary).toBe("Existing summary.");
+        });
+    });
+});

--- a/server/utils/conversation-history.js
+++ b/server/utils/conversation-history.js
@@ -1,0 +1,124 @@
+import { CONVERSATION_CONFIG } from "../../shared/constants.js";
+import { getConversationById, getMessagesByConversationId } from "../db/queries.js";
+
+/**
+ * Serializes assistant message blocks to a readable text string.
+ * @param {import("../../shared/types.js").MessageBlock[] | null} blocks
+ * @returns {string}
+ */
+export function serializeBlocks(blocks) {
+    if (!blocks || !Array.isArray(blocks)) {
+        return "";
+    }
+    const parts = [];
+    for (const block of blocks) {
+        if (!block || typeof block !== "object" || !block.type) {
+            continue;
+        }
+        switch (block.type) {
+            case "text": {
+                parts.push(block.markdown ?? "");
+                break;
+            }
+            case "callout": {
+                parts.push(`[${block.title ?? "Callout"}] ${block.markdown ?? ""}`);
+                break;
+            }
+            case "stat-block": {
+                parts.push(`[Stat Block: ${block.title ?? "Creature"}]`);
+                break;
+            }
+            case "rule-detail": {
+                parts.push(`[Rule Detail: ${block.title ?? "Item"}]`);
+                break;
+            }
+        }
+    }
+    return parts.join("\n\n");
+}
+
+/**
+ * Estimates token count for a contents array (~4 chars per token).
+ * @param {Array<{ role: string, parts: Array<{ text: string }> }>} contents
+ * @returns {number}
+ */
+export function estimateTokenCount(contents) {
+    let totalChars = 0;
+    for (const turn of contents) {
+        for (const part of turn.parts) {
+            totalChars += part.text.length;
+        }
+    }
+    return Math.ceil(totalChars / 4);
+}
+
+/**
+ * Returns true if estimated token count exceeds the compaction threshold.
+ * @param {Array<{ role: string, parts: Array<{ text: string }> }>} contents
+ * @param {number} [threshold]
+ * @returns {boolean}
+ */
+export function shouldCompact(
+    contents,
+    threshold = CONVERSATION_CONFIG.COMPACTION_THRESHOLD_TOKENS,
+) {
+    return estimateTokenCount(contents) > threshold;
+}
+
+/**
+ * Builds a Gemini-compatible contents array from conversation history.
+ * Expects the current user message to already be persisted in the DB.
+ * @param {import("bun:sqlite").Database} db
+ * @param {string} conversationId
+ * @returns {Array<{ role: string, parts: Array<{ text: string }> }>}
+ */
+export function formatConversationForLlm(db, conversationId) {
+    const messages = getMessagesByConversationId(db, conversationId);
+    const conversation = getConversationById(db, conversationId);
+
+    /** @type {Array<{ role: string, parts: Array<{ text: string }> }>} */
+    const contents = [];
+
+    if (conversation?.compactedSummary) {
+        contents.push({
+            role: "user",
+            parts: [
+                {
+                    text: `[Previous conversation summary]\n${conversation.compactedSummary}`,
+                },
+            ],
+        });
+        contents.push({
+            role: "model",
+            parts: [
+                {
+                    text: "Understood. I will use this conversation summary as context for our ongoing discussion.",
+                },
+            ],
+        });
+    }
+
+    const windowLimit = CONVERSATION_CONFIG.MAX_HISTORY_TURNS * 2;
+    const windowedMessages = messages.slice(-windowLimit);
+
+    for (const message of windowedMessages) {
+        if (message.role === "user") {
+            contents.push({
+                role: "user",
+                parts: [{ text: message.content ?? "" }],
+            });
+        } else if (message.role === "assistant") {
+            const text = serializeBlocks(
+                /** @type {import("../../shared/types.js").MessageBlock[] | null} */ (
+                    message.blocks
+                ),
+            );
+            contents.push({
+                role: "model",
+                parts: [{ text }],
+            });
+        }
+    }
+
+    return contents;
+}

--- a/server/utils/conversation-history.test.js
+++ b/server/utils/conversation-history.test.js
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import { createDb } from "../db/database.js";
+import { createConversation, createMessage, createUser } from "../db/queries.js";
+import {
+    estimateTokenCount,
+    formatConversationForLlm,
+    serializeBlocks,
+    shouldCompact,
+} from "./conversation-history.js";
+
+describe("conversation-history", () => {
+    describe("serializeBlocks", () => {
+        it("returns empty string for null blocks", () => {
+            expect(serializeBlocks(null)).toBe("");
+        });
+
+        it("returns empty string for empty array", () => {
+            expect(serializeBlocks([])).toBe("");
+        });
+
+        it("handles text blocks", () => {
+            const result = serializeBlocks([{ type: "text", markdown: "Hello Pathfinder!" }]);
+            expect(result).toBe("Hello Pathfinder!");
+        });
+
+        it("handles callout blocks", () => {
+            const result = serializeBlocks([
+                { type: "callout", title: "Key Rule", markdown: "**critical hit**" },
+            ]);
+            expect(result).toBe("[Key Rule] **critical hit**");
+        });
+
+        it("handles stat-block blocks", () => {
+            const result = serializeBlocks([
+                { type: "stat-block", title: "Mitflit King", ruleItemId: "abc-123" },
+            ]);
+            expect(result).toBe("[Stat Block: Mitflit King]");
+        });
+
+        it("handles rule-detail blocks", () => {
+            const result = serializeBlocks([
+                { type: "rule-detail", title: "Enfeebled", ruleItemId: "def-456" },
+            ]);
+            expect(result).toBe("[Rule Detail: Enfeebled]");
+        });
+
+        it("uses default titles for stat-block without title", () => {
+            const result = serializeBlocks([{ type: "stat-block", ruleItemId: "abc-123" }]);
+            expect(result).toBe("[Stat Block: Creature]");
+        });
+
+        it("uses default titles for rule-detail without title", () => {
+            const result = serializeBlocks([{ type: "rule-detail", ruleItemId: "def-456" }]);
+            expect(result).toBe("[Rule Detail: Item]");
+        });
+
+        it("handles mixed block types", () => {
+            const result = serializeBlocks([
+                { type: "text", markdown: "Intro text" },
+                { type: "callout", title: "Note", markdown: "See below" },
+                { type: "stat-block", title: "Goblin", ruleItemId: "abc" },
+            ]);
+            expect(result).toBe("Intro text\n\n[Note] See below\n\n[Stat Block: Goblin]");
+        });
+
+        it("skips null entries gracefully", () => {
+            const result = serializeBlocks(
+                /** @type {import("../../shared/types.js").MessageBlock[]} */ ([
+                    null,
+                    { type: "text", markdown: "valid" },
+                ]),
+            );
+            expect(result).toBe("valid");
+        });
+    });
+
+    describe("estimateTokenCount", () => {
+        it("returns reasonable estimate for known strings", () => {
+            const contents = [{ role: "user", parts: [{ text: "a".repeat(400) }] }];
+            const tokens = estimateTokenCount(contents);
+            expect(tokens).toBe(100);
+        });
+
+        it("sums across multiple turns", () => {
+            const contents = [
+                { role: "user", parts: [{ text: "a".repeat(200) }] },
+                { role: "model", parts: [{ text: "b".repeat(200) }] },
+            ];
+            const tokens = estimateTokenCount(contents);
+            expect(tokens).toBe(100);
+        });
+    });
+
+    describe("shouldCompact", () => {
+        it("returns false for short contents", () => {
+            const contents = [{ role: "user", parts: [{ text: "Hello" }] }];
+            expect(shouldCompact(contents)).toBe(false);
+        });
+
+        it("returns true for contents exceeding threshold", () => {
+            const longText = "x".repeat(500000 * 4 + 1);
+            const contents = [{ role: "user", parts: [{ text: longText }] }];
+            expect(shouldCompact(contents)).toBe(true);
+        });
+
+        it("respects custom threshold", () => {
+            const contents = [{ role: "user", parts: [{ text: "a".repeat(100) }] }];
+            expect(shouldCompact(contents, 10)).toBe(true);
+            expect(shouldCompact(contents, 100)).toBe(false);
+        });
+    });
+
+    describe("formatConversationForLlm", () => {
+        /** @type {ReturnType<typeof createDb>} */
+        let db;
+        /** @type {string} */
+        let convId;
+
+        beforeEach(() => {
+            db = createDb(":memory:");
+            const user = createUser(db, {
+                name: "Test User",
+                initials: "TU",
+                subtitle: "Test",
+                mode: "player",
+                email: null,
+                isTestUser: false,
+            });
+            const conv = createConversation(db, { title: "Test Chat", userId: user.id });
+            convId = conv.id;
+        });
+
+        afterEach(() => {
+            if (db) {
+                db.close();
+            }
+        });
+
+        it("returns single user turn when no history exists", () => {
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "Hello",
+                blocksJson: null,
+            });
+
+            const contents = formatConversationForLlm(db, convId);
+
+            expect(contents).toHaveLength(1);
+            expect(contents[0].role).toBe("user");
+            expect(contents[0].parts[0].text).toBe("Hello");
+        });
+
+        it("returns alternating user/model turns for multi-message conversation", () => {
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "First question",
+                blocksJson: null,
+            });
+            createMessage(db, {
+                conversationId: convId,
+                role: "assistant",
+                mode: "player",
+                content: null,
+                blocksJson: JSON.stringify([{ type: "text", markdown: "First answer" }]),
+            });
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "Follow-up question",
+                blocksJson: null,
+            });
+
+            const contents = formatConversationForLlm(db, convId);
+
+            expect(contents).toHaveLength(3);
+            expect(contents[0].role).toBe("user");
+            expect(contents[0].parts[0].text).toBe("First question");
+            expect(contents[1].role).toBe("model");
+            expect(contents[1].parts[0].text).toContain("First answer");
+            expect(contents[2].role).toBe("user");
+            expect(contents[2].parts[0].text).toBe("Follow-up question");
+        });
+
+        it("correctly serializes assistant blocks to text", () => {
+            createMessage(db, {
+                conversationId: convId,
+                role: "assistant",
+                mode: "player",
+                content: null,
+                blocksJson: JSON.stringify([
+                    { type: "text", markdown: "Some info" },
+                    { type: "stat-block", title: "Goblin", ruleItemId: "ri1" },
+                ]),
+            });
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "Next question",
+                blocksJson: null,
+            });
+
+            const contents = formatConversationForLlm(db, convId);
+
+            const modelTurn = contents.find((c) => c.role === "model");
+            expect(modelTurn).toBeDefined();
+            expect(modelTurn?.parts[0].text).toContain("Some info");
+            expect(modelTurn?.parts[0].text).toContain("[Stat Block: Goblin]");
+        });
+
+        it("prepends compacted summary as pseudo-turn when compactedSummary exists", () => {
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "Old question",
+                blocksJson: null,
+            });
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "New question",
+                blocksJson: null,
+            });
+
+            db.run("UPDATE conversations SET compacted_summary = ? WHERE id = ?", [
+                "We discussed goblins and fireballs.",
+                convId,
+            ]);
+
+            const contents = formatConversationForLlm(db, convId);
+
+            expect(contents[0].role).toBe("user");
+            expect(contents[0].parts[0].text).toContain("Previous conversation summary");
+            expect(contents[0].parts[0].text).toContain("We discussed goblins and fireballs.");
+            expect(contents[1].role).toBe("model");
+            expect(contents[1].parts[0].text).toContain("Understood");
+
+            const lastTurn = contents[contents.length - 1];
+            expect(lastTurn.role).toBe("user");
+            expect(lastTurn.parts[0].text).toBe("New question");
+        });
+
+        it("applies window limit to history messages", () => {
+            for (let i = 0; i < 50; i++) {
+                createMessage(db, {
+                    conversationId: convId,
+                    role: "user",
+                    mode: "player",
+                    content: `Question ${i}`,
+                    blocksJson: null,
+                });
+                createMessage(db, {
+                    conversationId: convId,
+                    role: "assistant",
+                    mode: "player",
+                    content: null,
+                    blocksJson: JSON.stringify([{ type: "text", markdown: `Answer ${i}` }]),
+                });
+            }
+
+            const contents = formatConversationForLlm(db, convId);
+
+            // Window is 20 turns * 2 = 40 messages
+            expect(contents).toHaveLength(40);
+            expect(contents[0].parts[0].text).toBe("Question 30");
+            expect(contents[contents.length - 1].role).toBe("model");
+            expect(contents[contents.length - 1].parts[0].text).toContain("Answer 49");
+        });
+
+        it("includes persisted user message from DB without duplication", () => {
+            createMessage(db, {
+                conversationId: convId,
+                role: "user",
+                mode: "player",
+                content: "My current message",
+                blocksJson: null,
+            });
+
+            const contents = formatConversationForLlm(db, convId);
+
+            const userTurns = contents.filter((c) => c.role === "user");
+            expect(userTurns).toHaveLength(1);
+            expect(userTurns[0].parts[0].text).toBe("My current message");
+        });
+    });
+});

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -129,12 +129,12 @@ A non-creature rule item (trait, condition, feat, etc.) that has its OWN dedicat
 
 /**
  * Calls the Gemini API with JSON mode to get a structured response.
- * @param {string} userMessage - The user's chat message
+ * @param {Array<{role: string, parts: Array<{text: string}>}>} contents - Full conversation turns
  * @param {string} ragContext - RAG-retrieved context (empty string if none)
  * @param {string} mode - "player" or "gm"
  * @returns {Promise<MessageBlock[]>}
  */
-export async function callGeminiJson(userMessage, ragContext, mode) {
+export async function callGeminiJson(contents, ragContext, mode) {
     const apiKey = process.env.GOOGLE_AI_API_KEY;
     if (!apiKey) {
         throw new Error("GOOGLE_AI_API_KEY environment variable is not set");
@@ -143,7 +143,7 @@ export async function callGeminiJson(userMessage, ragContext, mode) {
     const url = `${GEMINI_API_BASE}/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
 
     const requestBody = {
-        contents: [{ role: "user", parts: [{ text: userMessage }] }],
+        contents: contents,
         systemInstruction: {
             parts: [{ text: buildSystemPrompt(ragContext, mode) }],
         },
@@ -206,15 +206,15 @@ export async function callGeminiJson(userMessage, ragContext, mode) {
 
 /**
  * Gets an LLM response, falling back to mock on any error.
- * @param {string} userMessage - The user's chat message
+ * @param {Array<{role: string, parts: Array<{text: string}>}>} contents - Full conversation turns
  * @param {string} ragContext - RAG-retrieved context (empty string if none)
  * @param {string} mode - "player" or "gm"
  * @param {string} [userId]
  * @returns {Promise<MessageBlock[]>}
  */
-export async function getLlmResponse(userMessage, ragContext, mode, userId) {
+export async function getLlmResponse(contents, ragContext, mode, userId) {
     try {
-        return await callGeminiJson(userMessage, ragContext, mode);
+        return await callGeminiJson(contents, ragContext, mode);
     } catch (error) {
         if (error instanceof RetryableError) {
             throw error;
@@ -223,4 +223,58 @@ export async function getLlmResponse(userMessage, ragContext, mode, userId) {
         console.warn("LLM client error, falling back to mock:", error);
         return getMockResponse(userId);
     }
+}
+
+/**
+ * Calls the Gemini API to produce a plain-text summary of conversation messages.
+ * Used for compaction — no JSON mode, no structured schema.
+ * @param {string} messagesText - Serialized conversation messages to summarize
+ * @returns {Promise<string>}
+ */
+export async function callGeminiForSummarization(messagesText) {
+    const apiKey = process.env.GOOGLE_AI_API_KEY;
+    if (!apiKey) {
+        throw new Error("GOOGLE_AI_API_KEY environment variable is not set");
+    }
+
+    const url = `${GEMINI_API_BASE}/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
+
+    const systemPrompt =
+        "You are summarizing a Pathfinder 2e RPG conversation. " +
+        "Produce a concise but comprehensive summary preserving all key facts, " +
+        "rules discussed, creatures mentioned, decisions made, and any ongoing " +
+        "questions or tasks. Write in plain text, not JSON.";
+
+    const requestBody = {
+        contents: [
+            {
+                role: "user",
+                parts: [
+                    {
+                        text: `Please summarize the following conversation:\n\n${messagesText}`,
+                    },
+                ],
+            },
+        ],
+        systemInstruction: {
+            parts: [{ text: systemPrompt }],
+        },
+    };
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Gemini summarization API error: ${response.status} ${errorText}`);
+    }
+
+    const responseData =
+        /** @type {{ candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> }} */ (
+            await response.json()
+        );
+    return responseData.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
 }

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -1,5 +1,5 @@
 import { GEMINI_API_BASE, GEMINI_MODEL } from "../../shared/constants.js";
-import { messageBlocksArraySchema } from "../../shared/schemas.js";
+import { geminiResponseSchema, messageBlocksArraySchema } from "../../shared/schemas.js";
 import { getMockResponse } from "./mock-response.js";
 
 export class RetryableError extends Error {
@@ -170,10 +170,7 @@ export async function callGeminiJson(contents, ragContext, mode) {
         throw new Error(`Gemini API error: ${response.status} ${errorText}`);
     }
 
-    const responseData =
-        /** @type {{ candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> }} */ (
-            await response.json()
-        );
+    const responseData = geminiResponseSchema.parse(await response.json());
     /** @type {string} */
     const rawText = responseData.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
 
@@ -272,9 +269,6 @@ export async function callGeminiForSummarization(messagesText) {
         throw new Error(`Gemini summarization API error: ${response.status} ${errorText}`);
     }
 
-    const responseData =
-        /** @type {{ candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }> }} */ (
-            await response.json()
-        );
+    const responseData = geminiResponseSchema.parse(await response.json());
     return responseData.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
 }

--- a/server/utils/llm-client.test.js
+++ b/server/utils/llm-client.test.js
@@ -5,6 +5,7 @@ import {
     RetryableError,
     buildGeminiResponseSchema,
     buildSystemPrompt,
+    callGeminiForSummarization,
     callGeminiJson,
     getLlmResponse,
 } from "./llm-client.js";
@@ -57,7 +58,11 @@ describe("llm-client", () => {
             const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            const result = await callGeminiJson("Tell me about crits", "", "player");
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "Tell me about crits" }] }],
+                "",
+                "player",
+            );
 
             expect(result).toEqual(blocks);
             expect(fetchMock).toHaveBeenCalled();
@@ -71,7 +76,11 @@ describe("llm-client", () => {
             const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            await callGeminiJson("test message", "some context", "gm");
+            await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test message" }] }],
+                "some context",
+                "gm",
+            );
 
             const calls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock.mock.calls)
@@ -106,9 +115,9 @@ describe("llm-client", () => {
                 }),
             );
 
-            expect(callGeminiJson("test", "", "player")).rejects.toThrow(
-                "Gemini API error: 500 Internal Server Error",
-            );
+            expect(
+                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("Gemini API error: 500 Internal Server Error");
         });
 
         it("throws with rate limit message on 429", async () => {
@@ -121,9 +130,9 @@ describe("llm-client", () => {
                 }),
             );
 
-            expect(callGeminiJson("test", "", "player")).rejects.toThrow(
-                "Gemini API rate limit exceeded",
-            );
+            expect(
+                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("Gemini API rate limit exceeded");
         });
 
         it("throws RetryableError on 503", async () => {
@@ -137,7 +146,7 @@ describe("llm-client", () => {
             );
 
             try {
-                await callGeminiJson("test", "", "player");
+                await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
                 expect.unreachable("Should have thrown");
             } catch (error) {
                 expect(error).toBeInstanceOf(RetryableError);
@@ -151,7 +160,11 @@ describe("llm-client", () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             mockFetch(() => Promise.resolve(geminiResponse("not valid json {")));
 
-            const result = await callGeminiJson("test", "", "player");
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
 
             expect(result).toEqual([{ type: "text", markdown: "not valid json {" }]);
         });
@@ -161,7 +174,11 @@ describe("llm-client", () => {
             const invalidBlocks = [{ type: "unknown-type", foo: "bar" }];
             mockFetch(() => Promise.resolve(geminiResponse(JSON.stringify(invalidBlocks))));
 
-            const result = await callGeminiJson("test", "", "player");
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
 
             expect(result).toEqual([{ type: "text", markdown: JSON.stringify(invalidBlocks) }]);
         });
@@ -169,9 +186,9 @@ describe("llm-client", () => {
         it("throws when API key is missing", async () => {
             delete process.env.GOOGLE_AI_API_KEY;
 
-            expect(callGeminiJson("test", "", "player")).rejects.toThrow(
-                "GOOGLE_AI_API_KEY environment variable is not set",
-            );
+            expect(
+                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("GOOGLE_AI_API_KEY environment variable is not set");
         });
 
         it("sends system instruction in request body", async () => {
@@ -182,7 +199,7 @@ describe("llm-client", () => {
             const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            await callGeminiJson("test", "", "player");
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
 
             const calls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock.mock.calls)
@@ -201,7 +218,7 @@ describe("llm-client", () => {
             const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            await callGeminiJson("test", "", "player");
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
             const playerCalls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock.mock.calls)
             );
@@ -213,7 +230,7 @@ describe("llm-client", () => {
             const fetchMock2 = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock2));
 
-            await callGeminiJson("test", "", "gm");
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "gm");
             const gmCalls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock2.mock.calls)
             );
@@ -229,7 +246,11 @@ describe("llm-client", () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             mockFetch(() => Promise.resolve(geminiResponse("[]")));
 
-            const result = await callGeminiJson("test", "", "player");
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
 
             expect(result).toEqual([
                 {
@@ -242,7 +263,11 @@ describe("llm-client", () => {
 
     describe("getLlmResponse", () => {
         it("falls back to mock response on error", async () => {
-            const result = await getLlmResponse("test", "", "player");
+            const result = await getLlmResponse(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
 
             expect(Array.isArray(result)).toBe(true);
             expect(result.length).toBeGreaterThan(0);
@@ -259,7 +284,7 @@ describe("llm-client", () => {
             );
 
             try {
-                await getLlmResponse("test", "", "player");
+                await getLlmResponse([{ role: "user", parts: [{ text: "test" }] }], "", "player");
                 expect.unreachable("Should have thrown");
             } catch (error) {
                 expect(error).toBeInstanceOf(RetryableError);
@@ -275,7 +300,11 @@ describe("llm-client", () => {
             ];
             mockFetch(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
 
-            const result = await getLlmResponse("test", "", "player");
+            const result = await getLlmResponse(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
 
             expect(result).toEqual(blocks);
         });
@@ -302,6 +331,60 @@ describe("llm-client", () => {
             const prompt = buildSystemPrompt("", "player");
 
             expect(prompt).not.toContain("retrieved-context");
+        });
+    });
+
+    describe("callGeminiForSummarization", () => {
+        it("returns summary text on success", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() => Promise.resolve(geminiResponse("Summary of the conversation.")));
+
+            const result = await callGeminiForSummarization("Some messages text");
+
+            expect(result).toBe("Summary of the conversation.");
+        });
+
+        it("sends summarization prompt in request", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse("Summary")));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiForSummarization("messages");
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+
+            expect(body.systemInstruction).toBeDefined();
+            expect(body.systemInstruction.parts[0].text).toContain("Pathfinder");
+            expect(body.contents[0].parts[0].text).toContain("messages");
+            expect(body.generationConfig).toBeUndefined();
+        });
+
+        it("throws on API error", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    text: () => Promise.resolve("Server Error"),
+                }),
+            );
+
+            expect(callGeminiForSummarization("text")).rejects.toThrow(
+                "Gemini summarization API error",
+            );
+        });
+
+        it("throws when API key is missing", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            expect(callGeminiForSummarization("text")).rejects.toThrow(
+                "GOOGLE_AI_API_KEY environment variable is not set",
+            );
         });
     });
 

--- a/shared/constants.js
+++ b/shared/constants.js
@@ -15,6 +15,13 @@ export const RAG_CONFIG = {
 export const GEMINI_MODEL = "gemini-2.5-flash";
 export const GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models";
 
+/** Conversation history configuration */
+export const CONVERSATION_CONFIG = {
+    MAX_HISTORY_TURNS: 20,
+    COMPACTION_THRESHOLD_TOKENS: 500000,
+    COMPACTION_KEEP_RECENT_TURNS: 10,
+};
+
 /** Deterministic UUIDs for seed data — stable across restarts, usable in tests */
 export const SEED_IDS = {
     USER_DEFAULT: "00000000-0000-4000-8000-000000000001",

--- a/shared/schemas.js
+++ b/shared/schemas.js
@@ -219,6 +219,26 @@ const messageBlockSchema = z.union([
 
 const messageBlocksArraySchema = z.array(messageBlockSchema);
 
+// --- Gemini API response schema for summarization validation ---
+
+const geminiResponseSchema = z.object({
+    candidates: z
+        .array(
+            z.object({
+                content: z
+                    .object({
+                        parts: z.array(
+                            z.object({
+                                text: z.string().optional(),
+                            }),
+                        ),
+                    })
+                    .optional(),
+            }),
+        )
+        .optional(),
+});
+
 export {
     uuidSchema,
     conversationIdSchema,
@@ -246,4 +266,5 @@ export {
     ruleDetailBlockSchema,
     messageBlockSchema,
     messageBlocksArraySchema,
+    geminiResponseSchema,
 };

--- a/shared/types.js
+++ b/shared/types.js
@@ -1,6 +1,6 @@
 /** @typedef {"player" | "gm"} Mode */
 
-/** @typedef {{ id: string, title: string, userId?: string, createdAt?: string }} Conversation */
+/** @typedef {{ id: string, title: string, userId?: string, createdAt?: string, compactedSummary?: string | null }} Conversation */
 
 /** @typedef {{ id: string, name: string, initials: string, subtitle: string, mode: Mode, email: string | null, isTestUser?: boolean, webauthnUserId?: string }} AuthUser */
 


### PR DESCRIPTION
## Summary

Closes #88

- Fetch full conversation history from DB and pass as multi-turn `contents[]` to Gemini API (previously only current prompt was sent)
- Token-based compaction: when history exceeds threshold (500K tokens), old messages are summarized via a dedicated LLM call and stored as `compacted_summary` on the conversation
- Subsequent calls reuse stored summary — no repeated summarization
- Embedding/RAG queries unchanged — only current message embedded (correct per RAG best practices)

## Changes

### Modified
| File | Change |
|------|--------|
| `shared/constants.js` | `CONVERSATION_CONFIG` constants |
| `shared/types.js` | `compactedSummary` on `Conversation` |
| `server/db/migrate.js` | `compacted_summary` column migration |
| `server/db/queries.js` | Updated query + `updateCompactedSummary` |
| `server/utils/llm-client.js` | `contents[]` array signatures, `callGeminiForSummarization` |
| `server/routes/messages.js` | History formatting + compaction in stream handler |

### New
| File | Purpose |
|------|---------|
| `server/utils/conversation-history.js` | History formatting, token estimation, window logic |
| `server/utils/compaction.js` | Summarization orchestration with early-return guard |
| `server/utils/conversation-history.test.js` | 8 tests |
| `server/utils/compaction.test.js` | 4 tests |

## Test Results
- 628 tests pass, 0 fail
- Typecheck, lint, formatting all clean