### PR TITLE
fix: prevent Gemini repetition loops and fix SSE/message ordering bugs

### DIFF
--- a/.changeset/fix-gemini-repetition.md
+++ b/.changeset/fix-gemini-repetition.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fix Gemini repetition loops by adding temperature/topP/maxOutputTokens params, fix compaction ordering so summaries are included in LLM calls, and fix SSE stream parsing to buffer partial lines across chunks.

--- a/client/stores/messages-store.js
+++ b/client/stores/messages-store.js
@@ -56,6 +56,7 @@ function createMessagesStore() {
         async *parseSSEStream(body) {
             const reader = body.getReader();
             const decoder = new TextDecoder();
+            let buffer = "";
 
             try {
                 while (true) {
@@ -63,10 +64,14 @@ function createMessagesStore() {
                     if (result.done) {
                         break;
                     }
-                    const value = result.value;
-                    const chunk = decoder.decode(value, { stream: true });
-                    const lines = chunk.split("\n").filter(Boolean);
-                    for (const line of lines) {
+                    const chunk = decoder.decode(result.value, { stream: true });
+                    buffer += chunk;
+                    const parts = buffer.split("\n");
+                    buffer = /** @type {string} */ (parts.pop());
+                    for (const line of parts) {
+                        if (!line) {
+                            continue;
+                        }
                         /** @type {unknown} */
                         const data = JSON.parse(line);
                         if (
@@ -80,6 +85,21 @@ function createMessagesStore() {
                             const typedData = /** @type {SSEEvent} */ (data);
                             yield typedData;
                         }
+                    }
+                }
+                if (buffer) {
+                    /** @type {unknown} */
+                    const data = JSON.parse(buffer);
+                    if (
+                        typeof data === "object" &&
+                        data !== null &&
+                        "type" in data &&
+                        typeof data.type === "string" &&
+                        "data" in data
+                    ) {
+                        /** @type {SSEEvent} */
+                        const typedData = /** @type {SSEEvent} */ (data);
+                        yield typedData;
                     }
                 }
             } finally {

--- a/client/stores/messages-store.test.js
+++ b/client/stores/messages-store.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+
+import { createMessagesStore } from "./messages-store.js";
+
+/**
+ * Creates a ReadableStream that enqueues the given chunks then closes.
+ * Each chunk is string content (will be Uint8Array-encoded).
+ * @param {string[]} chunks
+ * @returns {ReadableStream<Uint8Array>}
+ */
+function mockStream(chunks) {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+        start(controller) {
+            for (const chunk of chunks) {
+                controller.enqueue(encoder.encode(chunk));
+            }
+            controller.close();
+        },
+    });
+}
+
+/**
+ * Collects all events from an async generator into an array.
+ * @param {AsyncGenerator<import("./messages-store.js").SSEEvent>} gen
+ * @returns {Promise<Array<{ type: string, data: unknown }>>}
+ */
+async function collect(gen) {
+    /** @type {Array<{ type: string, data: unknown }>} */
+    const events = [];
+    for await (const event of gen) {
+        events.push(event);
+    }
+    return events;
+}
+
+describe("parseSSEStream", () => {
+    it("parses a single JSON line in one chunk", async () => {
+        const stream = mockStream(['{"type":"test","data":42}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ type: "test", data: 42 });
+    });
+
+    it("parses multiple JSON lines in one chunk", async () => {
+        const stream = mockStream([
+            '{"type":"a","data":1}\n{"type":"b","data":2}\n{"type":"c","data":3}\n',
+        ]);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(3);
+        expect(events[0]).toEqual({ type: "a", data: 1 });
+        expect(events[1]).toEqual({ type: "b", data: 2 });
+        expect(events[2]).toEqual({ type: "c", data: 3 });
+    });
+
+    it("reassembles a line split across two chunks", async () => {
+        const stream = mockStream(['{"type":"te', 'st","data":42}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ type: "test", data: 42 });
+    });
+
+    it("reassembles a line split at a newline boundary", async () => {
+        const stream = mockStream(['{"type":"a","data":1}\n{"type":"b', '","data":2}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({ type: "a", data: 1 });
+        expect(events[1]).toEqual({ type: "b", data: 2 });
+    });
+
+    it("reassembles a line split across three chunks", async () => {
+        const stream = mockStream(['{"type', '":"test","', 'data":42}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ type: "test", data: 42 });
+    });
+
+    it("flushes remaining buffer at end of stream", async () => {
+        const stream = mockStream(['{"type":"test","data":42}']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ type: "test", data: 42 });
+    });
+
+    it("skips empty lines between valid lines", async () => {
+        const stream = mockStream(['{"type":"a","data":1}\n\n{"type":"b","data":2}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({ type: "a", data: 1 });
+        expect(events[1]).toEqual({ type: "b", data: 2 });
+    });
+
+    it("handles multi-byte characters split across chunks", async () => {
+        const stream = mockStream(['{"type":"test","data":"caf', "\\u00e9", '"}\n']);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ type: "test", data: "café" });
+    });
+
+    it("yields nothing for an empty stream", async () => {
+        const stream = mockStream([]);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(0);
+    });
+
+    it("strips items missing required SSE shape", async () => {
+        const stream = mockStream([
+            '{"type":"valid","data":1}\n{"notype":true}\n{"type":"alsoValid","data":2}\n',
+        ]);
+        const events = await collect(createMessagesStore().parseSSEStream(stream));
+
+        expect(events).toHaveLength(2);
+        expect(events[0]).toEqual({ type: "valid", data: 1 });
+        expect(events[1]).toEqual({ type: "alsoValid", data: 2 });
+    });
+});

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -385,14 +385,14 @@ async function runResponseStream(honoStream, ctx) {
         embeddingTokens = ragContext.embeddingTokens ?? 0;
         const isUngrounded = ragResultCount === 0;
 
-        const llmContents = formatConversationForLlm(db, actualConvId);
+        const llmContentsBefore = formatConversationForLlm(db, actualConvId);
 
         try {
-            await compactConversation(db, actualConvId, llmContents);
+            await compactConversation(db, actualConvId, llmContentsBefore);
         } catch (compactionError) {
             // oxlint-disable-next-line no-console -- just log and continue; compaction failure shouldn't block the user response
             console.error("Compaction failed:", compactionError);
-            if (shouldCompact(llmContents)) {
+            if (shouldCompact(llmContentsBefore)) {
                 await sendEvent({
                     type: "compactionWarning",
                     data: {
@@ -402,6 +402,8 @@ async function runResponseStream(honoStream, ctx) {
                 });
             }
         }
+
+        const llmContents = formatConversationForLlm(db, actualConvId);
 
         const llmResult = await getLlmResponseWithRetry(
             {

--- a/server/routes/messages.test.js
+++ b/server/routes/messages.test.js
@@ -1042,3 +1042,142 @@ describe("messages routes — error handling", () => {
         }
     });
 });
+
+describe("messages routes — compaction ordering", () => {
+    /** @type {Hono<any>} */
+    let app;
+    /** @type {ReturnType<typeof createDb>} */
+    let db;
+    /** @type {string} */
+    let sessionToken;
+    /** @type {string} */
+    let SEED_USER_ID;
+    /** @type {string} */
+    let convId;
+
+    beforeEach(async () => {
+        const { seedIfNeeded, SEED_IDS: seedIds } = await import("../db/seed.js");
+        SEED_USER_ID = seedIds.USER_DEFAULT;
+
+        db = createDb(":memory:");
+        seedIfNeeded(db);
+
+        const { conversationsRouter } = await import("./conversations.js");
+        const { sessionMiddleware } = await import("../middleware/session.js");
+        const { databaseMiddleware } = await import("../middleware/database.js");
+        const { createSession, createConversation } = await import("../db/queries.js");
+
+        app = new Hono()
+            .use("/api/*", databaseMiddleware({ database: db }))
+            .use("/api/conversations/*", sessionMiddleware({ database: db }))
+            .route("/api/conversations", conversationsRouter);
+
+        const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+        const session = createSession(db, {
+            userId: SEED_USER_ID,
+            token: crypto.randomUUID(),
+            expiresAt,
+        });
+        sessionToken = session.token;
+
+        const conv = createConversation(db, {
+            title: "Compaction Test",
+            userId: SEED_USER_ID,
+        });
+        convId = conv.id;
+    });
+
+    afterEach(() => {
+        if (db) {
+            db.close();
+        }
+    });
+
+    it("passes compacted summary to the LLM after compaction", async () => {
+        const originalFetch = globalThis.fetch;
+        const { mock } = await import("bun:test");
+
+        db.run("UPDATE conversations SET compacted_summary = ? WHERE id = ?", [
+            "This is a test summary of the previous conversation.",
+            convId,
+        ]);
+
+        /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+        const fetchMock = mock(() =>
+            Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve("") }),
+        );
+        globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+        process.env.GOOGLE_AI_API_KEY = "test-key";
+
+        fetchMock.mockImplementation(() => {
+            const url = /** @type {string[]} */ (fetchMock.mock.calls.at(-1))?.[0];
+            if (typeof url === "string" && url.includes("generateContent")) {
+                return Promise.resolve({
+                    ok: true,
+                    json: () =>
+                        Promise.resolve({
+                            candidates: [
+                                {
+                                    content: {
+                                        parts: [
+                                            {
+                                                text: JSON.stringify([
+                                                    { type: "text", markdown: "Hi" },
+                                                ]),
+                                            },
+                                        ],
+                                    },
+                                },
+                            ],
+                        }),
+                });
+            }
+            return Promise.resolve({
+                ok: false,
+                status: 500,
+                text: () => Promise.resolve("Not mocked"),
+            });
+        });
+
+        try {
+            const res = await app.request(`/api/conversations/${convId}/messages`, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "x-session-token": sessionToken,
+                },
+                body: JSON.stringify({ content: "Hello", mode: "player" }),
+            });
+            await res.text();
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+
+            const llmCall = calls.find(([url, init]) => {
+                if (typeof url !== "string" || !url.includes("generateContent")) {
+                    return false;
+                }
+                const body = JSON.parse(/** @type {string} */ (init.body));
+                return body.generationConfig !== undefined;
+            });
+
+            expect(llmCall).toBeDefined();
+            if (!llmCall) {
+                return;
+            }
+
+            const body = JSON.parse(/** @type {string} */ (llmCall[1].body));
+            const userContent = body.contents.find(
+                /** @param {{ role: string }} c */ (c) => c.role === "user",
+            );
+            expect(userContent).toBeDefined();
+            expect(userContent.parts[0].text).toContain("[Previous conversation summary]");
+            expect(userContent.parts[0].text).toContain("This is a test summary");
+        } finally {
+            globalThis.fetch = originalFetch;
+            delete process.env.GOOGLE_AI_API_KEY;
+            mock.restore();
+        }
+    });
+});

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -373,6 +373,9 @@ export async function callGeminiJson(contents, ragContext, mode, ungrounded) {
         generationConfig: {
             responseMimeType: "application/json",
             responseSchema: sanitizedSchema,
+            temperature: 0.7,
+            topP: 0.9,
+            maxOutputTokens: 8192,
         },
     };
 

--- a/server/utils/llm-client.test.js
+++ b/server/utils/llm-client.test.js
@@ -110,6 +110,27 @@ describe("llm-client", () => {
             expect(body.generationConfig.responseSchema.type).toBe("array");
         });
 
+        it("includes repetition-prevention parameters in generationConfig", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const blocks = [{ type: "text", markdown: "Test" }];
+
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
+
+            const body = JSON.parse(
+                /** @type {string} */ (
+                    /** @type {[string, RequestInit][]} */ (
+                        /** @type {unknown} */ (fetchMock.mock.calls)
+                    )[0][1].body
+                ),
+            );
+            expect(body.generationConfig.temperature).toBe(0.7);
+            expect(body.generationConfig.topP).toBe(0.9);
+            expect(body.generationConfig.maxOutputTokens).toBe(8192);
+        });
+
         it("throws descriptive error on non-OK HTTP response", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             mockFetch(() =>


### PR DESCRIPTION
## Summary

- **Prevent Gemini repetition loops**: Add `temperature` (0.7), `topP` (0.9), and `maxOutputTokens` (8192) to Gemini `generationConfig` to stop the model from repeating the same sentence 148+ times in a single response.
- **Fix compaction ordering**: `formatConversationForLlm` is now called *after* `compactConversation`, so the LLM receives the compacted summary instead of the stale uncompacted history — preventing context overload that degrades generation quality.
- **Fix SSE stream parsing**: Replace silent `JSON.parse` error swallowing with proper line buffering across TCP chunks — partial lines are reassembled instead of discarded, eliminating confusing client-side data loss.
- **Add regression tests** (12 new tests) covering all three fixes.

## Related

Follows up on #110.