### PR TITLE
fix: implement dual-pass Gemini pipeline to prevent infinite token repetition (#115)

### DIFF
--- a/.changeset/fix-gemini-dual-pass.md
+++ b/.changeset/fix-gemini-dual-pass.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Fix Gemini infinite repetition loop by implementing a dual-pass LLM pipeline: Pass 1 generates creative content freely in Markdown, Pass 2 extracts structured JSON blocks. Adds reasoning scratchpad to the response schema as an additional safeguard.

--- a/server/routes/messages.test.js
+++ b/server/routes/messages.test.js
@@ -570,14 +570,32 @@ describe("messages routes — custom stat block resolution", () => {
     });
 
     /**
-     * Helper to mock Gemini to return specific blocks.
+     * Helper to mock Gemini to return specific blocks via dual-pass pipeline.
+     * Pass 1 returns plain text; Pass 2 returns scratchpad-wrapped JSON blocks.
      * @param {import("bun:test").Mock<() => Promise<unknown>>} fetchMock
      * @param {import("../../shared/types.js").MessageBlock[]} blocks
      */
     function mockGeminiBlocks(fetchMock, blocks) {
+        let callIndex = 0;
         fetchMock.mockImplementation(() => {
             const url = /** @type {string[]} */ (fetchMock.mock.calls.at(-1))?.[0];
             if (typeof url === "string" && url.includes("generateContent")) {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve({
+                        ok: true,
+                        json: () =>
+                            Promise.resolve({
+                                candidates: [
+                                    {
+                                        content: {
+                                            parts: [{ text: "Pass 1 creative output" }],
+                                        },
+                                    },
+                                ],
+                            }),
+                    });
+                }
                 return Promise.resolve({
                     ok: true,
                     json: () =>
@@ -585,7 +603,14 @@ describe("messages routes — custom stat block resolution", () => {
                             candidates: [
                                 {
                                     content: {
-                                        parts: [{ text: JSON.stringify(blocks) }],
+                                        parts: [
+                                            {
+                                                text: JSON.stringify({
+                                                    internal_reasoning_scratchpad: "Parsing blocks",
+                                                    blocks: blocks,
+                                                }),
+                                            },
+                                        ],
                                     },
                                 },
                             ],

--- a/server/utils/llm-client.js
+++ b/server/utils/llm-client.js
@@ -1,5 +1,5 @@
 import { GEMINI_API_BASE, GEMINI_MODEL } from "../../shared/constants.js";
-import { geminiResponseSchema, messageBlocksArraySchema } from "../../shared/schemas.js";
+import { dualPassResponseSchema, geminiResponseSchema } from "../../shared/schemas.js";
 import { getMockResponse } from "./mock-response.js";
 
 /**
@@ -45,9 +45,11 @@ export class RetryableError extends Error {
 
 /**
  * Builds the Gemini response schema matching the MessageBlock union.
+ * @param {{ withScratchpad?: boolean }} [options]
  * @returns {Record<string, unknown>}
  */
-export function buildGeminiResponseSchema() {
+export function buildGeminiResponseSchema(options) {
+    const withScratchpad = options?.withScratchpad ?? false;
     const textBlock = {
         type: "object",
         properties: {
@@ -284,7 +286,7 @@ export function buildGeminiResponseSchema() {
         required: ["type", "ruleItemId"],
     };
 
-    return {
+    const blocksArraySchema = {
         type: "array",
         items: {
             anyOf: [
@@ -296,6 +298,23 @@ export function buildGeminiResponseSchema() {
             ],
         },
     };
+
+    if (withScratchpad) {
+        return {
+            type: "object",
+            properties: {
+                internal_reasoning_scratchpad: {
+                    type: "string",
+                    description:
+                        "CRITICAL: Write down your step-by-step logic, trait filtering, and rule classifications here FIRST before populating any other field.",
+                },
+                blocks: blocksArraySchema,
+            },
+            required: ["internal_reasoning_scratchpad", "blocks"],
+        };
+    }
+
+    return blocksArraySchema;
 }
 
 /**
@@ -394,14 +413,160 @@ A non-creature rule item (trait, condition, feat, etc.) that has its OWN dedicat
 }
 
 /**
- * Calls the Gemini API with JSON mode to get a structured response.
- * @param {Array<{role: string, parts: Array<{text: string}>}>} contents - Full conversation turns
- * @param {string} ragContext - RAG-retrieved context (empty string if none)
- * @param {string} mode - "player" or "gm"
- * @param {boolean} [ungrounded=false] - When true, adjusts system prompt for ungrounded responses
- * @returns {Promise<{ blocks: import("../../shared/types.js").MessageBlock[], usage?: import("../../shared/types.js").UsageMeta }>}
+ * Builds the system prompt for Pass 1: Creative & Contextual Generation.
+ * @param {string} ragContext
+ * @param {string} mode
+ * @param {boolean} [ungrounded]
+ * @returns {string}
  */
-export async function callGeminiJson(contents, ragContext, mode, ungrounded) {
+export function buildCreativeSystemPrompt(ragContext, mode, ungrounded) {
+    const roleGuidance =
+        mode === "gm"
+            ? "You are advising a Game Master. Focus on encounter building, rules arbitration, NPC management, and running engaging games."
+            : "You are advising a player. Focus on character options, combat tactics, spell selection, and understanding rules.";
+
+    const ragSection = ragContext.length > 0 ? `\n\n## Reference Data\n${ragContext}` : "";
+
+    const ungroundedSection =
+        ungrounded === true
+            ? `\n\n## IMPORTANT — No Reference Data Available
+The database search returned NO matching results for the user's question. You must:
+1. Begin your response by acknowledging that you don't have specific data in your database about this topic.
+2. Clearly indicate throughout your response that this information is from general knowledge, not verified database entries.
+3. Avoid presenting speculation as fact. If you're genuinely unsure, say so.
+4. Do NOT reference specific database IDs or stat-block/rule-detail markers.`
+            : "";
+
+    const playerRestrictions = `
+
+## Player Mode Restrictions
+You are responding to a PLAYER, not the Game Master. You must protect confidential game information:
+- NEVER reveal creature mechanics: AC, HP, saves, ability scores, skill modifiers, attack bonuses, damage dice, DCs, or spell details
+- Describe creatures narratively: appearance, size, observable traits, general behavior — what a character would see, not stat numbers
+- For lore questions, share only what is commonly known in the game world — preserve mysteries and secrets for the GM to reveal
+- When in doubt, err on the side of revealing less. Suggest "Ask your GM for more details" when appropriate`;
+
+    return `You are a Pathfinder 2e RPG assistant. ${roleGuidance}${mode === "player" ? playerRestrictions : ""}
+
+Think step-by-step and lay out all components clearly in structured Markdown.
+
+## Output Structure
+
+Produce your response in structured Markdown following these conventions:
+
+### Narrative Text
+Use plain paragraphs with markdown formatting for explanations, descriptions, and lists:
+- **bold** for emphasis, *italic* for flavor text
+- \`code\` for game terms like \`DC 15\`
+- Bullet lists and numbered lists where appropriate
+- > Blockquotes for quoted rules
+
+### Key Rules / Callouts
+When highlighting an important rule, use a heading: \`## Key Rule: <title>\` followed by the rule body in markdown.
+
+### Stat Blocks from Reference Data
+When the reference data contains a creature, include a section like:
+\`\`\`
+--- STAT BLOCK ---
+Name: Creature Name
+ID: <ruleItemId from reference data>
+\`\`\`
+
+### Custom / Invented Stat Blocks
+When creating or inventing a creature NOT in reference data, include a structured section with full inline stats:
+\`\`\`
+--- CUSTOM STAT BLOCK ---
+Name: Creature Name
+Type: Short classification
+Level: <number>
+Traits: trait1, trait2, ...
+AC: <value>
+HP: <value>/<max>
+Fortitude: +<value>
+Reflex: +<value>
+Will: +<value>
+Speed: <value>
+STR: +<value>, DEX: +<value>, CON: +<value>, INT: +<value>, WIS: +<value>, CHA: +<value>
+Skills: Skill1 +<value>, Skill2 +<value>
+Melee: WeaponName +<attack> (<damage> <damageType>)
+Actions: ActionName (<actionType>) - description
+\`\`\`
+
+### Rule Details
+For non-creature rule items (traits, conditions, feats) with their own database entry:
+\`\`\`
+[RULE-DETAIL: <ruleItemId>]
+\`\`\`
+
+## Guidelines
+- Treat the reference data as your own knowledge. NEVER say "based on the provided data" or similar meta-phrases
+- Speak directly and confidently as a Pathfinder 2e expert
+- When the reference data contains a creature entry, ALWAYS include a STAT BLOCK section with the creature's ruleItemId
+- Combine sections to give a complete answer
+- Use markdown formatting: **bold** for key values, \`code\` for game terms
+- **NO DUPLICATION**: Do not repeat the same information multiple times
+- Respond directly and concisely as a helpful RPG assistant${ragSection}${ungroundedSection}`;
+}
+
+/**
+ * Builds the system prompt for Pass 2: Structural Extraction.
+ * @returns {string}
+ */
+export function buildExtractionSystemPrompt() {
+    return `You are a JSON transformation engine. You receive structured Markdown from a Pathfinder 2e assistant and must convert it into a JSON array of message blocks.
+
+Output ONLY a JSON object with this exact structure:
+{
+  "internal_reasoning_scratchpad": "Your step-by-step parsing logic here",
+  "blocks": [ ... array of message blocks ... ]
+}
+
+## Block Types
+
+### text
+Freeform markdown for narrative, explanations, or bullet lists.
+- Example: { "type": "text", "markdown": "You deal **2d6 fire damage** to the target." }
+- Use "italic": true for in-character dialogue or flavor text.
+
+### callout
+Important rules, key mechanics, or highlighted information. "title" is the heading.
+- Example: { "type": "callout", "title": "Critical Success", "markdown": "When you **critically succeed**..." }
+
+### custom-stat-block
+Custom or invented creature stat block with inline data. Use when the Markdown contains a CUSTOM STAT BLOCK section.
+- Example: { "type": "custom-stat-block", "title": "Sylvaris", "data": { "name": "Sylvaris", "type": "Humanoid", "level": 5, "traits": ["Elf", "Ranger"], "attributes": { "ac": { "value": 22 }, "hp": { "value": 75, "max": 75 } } } }
+- "data.type": Short classification (e.g. "Dragon", "Animal", "Humanoid"). NOT narrative prose.
+- The data object MUST include "name" and "level".
+- NEVER emit more than ONE custom-stat-block for the same creature.
+
+### stat-block
+Creature stat block from reference data. Use ONLY when the Markdown contains a STAT BLOCK section with an ID from reference data.
+- Example: { "type": "stat-block", "title": "Goblin Warrior", "ruleItemId": "abc-123" }
+- CRITICAL: "stat-block" MUST have a "ruleItemId" field and MUST NOT have a "data" field
+
+### rule-detail
+A non-creature rule item with its own database entry.
+- Example: { "type": "rule-detail", "ruleItemId": "abc-123" }
+- Use ONLY for items that have their own [RULE-DETAIL: ...] marker in the input
+
+## Rules
+- Output ONLY valid JSON. No markdown code fences, no extra text.
+- Each distinct concept gets its own block. Typically 2-5 blocks per response.
+- Preserve ALL information from the input — do not summarize or drop content.
+- **NO DUPLICATION**: Do not emit two blocks with the same information.`;
+}
+
+/**
+ * Pass 1: Creative & Contextual Generation.
+ * Calls Gemini with high temperature, no JSON schema constraint.
+ * Returns raw Markdown text with step-by-step reasoning.
+ * @param {Array<{role: string, parts: Array<{text: string}>}>} contents
+ * @param {string} ragContext
+ * @param {string} mode
+ * @param {boolean} [ungrounded]
+ * @returns {Promise<{ text: string, usage?: import("../../shared/types.js").UsageMeta }>}
+ */
+export async function callGeminiPass1(contents, ragContext, mode, ungrounded) {
     const apiKey = process.env.GOOGLE_AI_API_KEY;
     if (!apiKey) {
         throw new Error("GOOGLE_AI_API_KEY environment variable is not set");
@@ -409,19 +574,14 @@ export async function callGeminiJson(contents, ragContext, mode, ungrounded) {
 
     const url = `${GEMINI_API_BASE}/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
 
-    const rawSchema = buildGeminiResponseSchema();
-    const sanitizedSchema = stripAdditionalProperties(rawSchema);
-
     const requestBody = {
         contents: contents,
         systemInstruction: {
-            parts: [{ text: buildSystemPrompt(ragContext, mode, ungrounded) }],
+            parts: [{ text: buildCreativeSystemPrompt(ragContext, mode, ungrounded) }],
         },
         generationConfig: {
-            responseMimeType: "application/json",
-            responseSchema: sanitizedSchema,
-            temperature: 0.7,
-            topP: 0.9,
+            temperature: 0.85,
+            topP: 0.95,
             maxOutputTokens: 8192,
         },
     };
@@ -451,51 +611,136 @@ export async function callGeminiJson(contents, ragContext, mode, ungrounded) {
               totalTokenCount: responseData.usageMetadata.totalTokenCount,
           }
         : undefined;
-    /** @type {string} */
+
+    const text = responseData.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+
+    return { text, usage };
+}
+
+/**
+ * Pass 2: Structural Extraction.
+ * Calls Gemini with low temperature and strict JSON schema.
+ * Receives Pass 1 Markdown output and transforms it into structured blocks.
+ * This function can throw on HTTP errors, JSON parse failures, or schema
+ * validation failures — the caller (callGeminiJson) is responsible for
+ * fallback handling.
+ * @param {string} pass1Text - Raw Markdown from Pass 1
+ * @param {Record<string, unknown>} sanitizedSchema
+ * @returns {Promise<{ blocks: import("../../shared/types.js").MessageBlock[], usage?: import("../../shared/types.js").UsageMeta }>}
+ */
+export async function callGeminiPass2(pass1Text, sanitizedSchema) {
+    const apiKey = process.env.GOOGLE_AI_API_KEY;
+    if (!apiKey) {
+        throw new Error("GOOGLE_AI_API_KEY environment variable is not set");
+    }
+
+    const url = `${GEMINI_API_BASE}/${GEMINI_MODEL}:generateContent?key=${apiKey}`;
+
+    const requestBody = {
+        contents: [
+            {
+                role: "user",
+                parts: [{ text: pass1Text }],
+            },
+        ],
+        systemInstruction: {
+            parts: [{ text: buildExtractionSystemPrompt() }],
+        },
+        generationConfig: {
+            responseMimeType: "application/json",
+            responseSchema: sanitizedSchema,
+            temperature: 0.1,
+            topP: 0.5,
+            maxOutputTokens: 8192,
+        },
+    };
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        if (response.status === 503) {
+            throw new RetryableError(`Service temporarily unavailable: ${errorText}`);
+        }
+        if (response.status === 429) {
+            throw new Error(`Gemini API rate limit exceeded: ${errorText}`);
+        }
+        throw new Error(`Gemini API error: ${response.status} ${errorText}`);
+    }
+
+    const responseData = geminiResponseSchema.parse(await response.json());
+    const usage = responseData.usageMetadata
+        ? {
+              promptTokenCount: responseData.usageMetadata.promptTokenCount,
+              candidatesTokenCount: responseData.usageMetadata.candidatesTokenCount,
+              totalTokenCount: responseData.usageMetadata.totalTokenCount,
+          }
+        : undefined;
+
     const rawText = responseData.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
 
     /** @type {unknown} */
-    let parsed;
-    try {
-        parsed = JSON.parse(rawText);
-    } catch {
-        return { blocks: [{ type: "text", markdown: rawText }], usage: undefined };
+    const parsed = JSON.parse(rawText);
+
+    const validated = dualPassResponseSchema.parse(parsed);
+
+    return { blocks: validated.blocks, usage };
+}
+
+/**
+ * Calls the Gemini API with JSON mode to get a structured response.
+ * @param {Array<{role: string, parts: Array<{text: string}>}>} contents - Full conversation turns
+ * @param {string} ragContext - RAG-retrieved context (empty string if none)
+ * @param {string} mode - "player" or "gm"
+ * @param {boolean} [ungrounded=false] - When true, adjusts system prompt for ungrounded responses
+ * @returns {Promise<{ blocks: import("../../shared/types.js").MessageBlock[], usage?: import("../../shared/types.js").UsageMeta }>}
+ */
+export async function callGeminiJson(contents, ragContext, mode, ungrounded) {
+    const apiKey = process.env.GOOGLE_AI_API_KEY;
+    if (!apiKey) {
+        throw new Error("GOOGLE_AI_API_KEY environment variable is not set");
     }
 
-    let blocks;
+    const pass1 = await callGeminiPass1(contents, ragContext, mode, ungrounded);
+
     try {
-        blocks = messageBlocksArraySchema.parse(parsed);
-    } catch {
+        const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+        const sanitizedSchema = stripAdditionalProperties(rawSchema);
+        const pass2 = await callGeminiPass2(pass1.text, sanitizedSchema);
+
+        const usage =
+            pass1.usage && pass2.usage
+                ? {
+                      promptTokenCount:
+                          (pass1.usage.promptTokenCount ?? 0) + (pass2.usage.promptTokenCount ?? 0),
+                      candidatesTokenCount:
+                          (pass1.usage.candidatesTokenCount ?? 0) +
+                          (pass2.usage.candidatesTokenCount ?? 0),
+                      totalTokenCount:
+                          (pass1.usage.totalTokenCount ?? 0) + (pass2.usage.totalTokenCount ?? 0),
+                  }
+                : (pass1.usage ?? pass2.usage);
+
+        if (pass2.blocks.length === 0) {
+            return {
+                blocks: [{ type: "text", markdown: pass1.text }],
+                usage: pass1.usage,
+            };
+        }
+
+        return { blocks: pass2.blocks, usage };
+    } catch (pass2Error) {
         // oxlint-disable-next-line no-console
-        console.warn(
-            "Gemini JSON response failed block schema validation — raw text:",
-            rawText.slice(0, 200),
-        );
+        console.warn("Pass 2 failed, falling back to Pass 1 text:", pass2Error);
         return {
-            blocks: [
-                {
-                    type: "text",
-                    markdown:
-                        "The AI produced a response that couldn't be displayed properly. Please try rephrasing your question or starting a new conversation.",
-                },
-            ],
-            usage: undefined,
+            blocks: [{ type: "text", markdown: pass1.text }],
+            usage: pass1.usage,
         };
     }
-
-    if (blocks.length === 0) {
-        return {
-            blocks: [
-                {
-                    type: "text",
-                    markdown: "I couldn't generate a response. Please try again.",
-                },
-            ],
-            usage: undefined,
-        };
-    }
-
-    return { blocks, usage };
 }
 
 /**

--- a/server/utils/llm-client.test.js
+++ b/server/utils/llm-client.test.js
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 
-import { GEMINI_API_BASE, GEMINI_MODEL } from "../../shared/constants.js";
 import {
     RetryableError,
+    buildCreativeSystemPrompt,
+    buildExtractionSystemPrompt,
     buildGeminiResponseSchema,
     buildSystemPrompt,
     callGeminiForSummarization,
     callGeminiJson,
+    callGeminiPass1,
+    callGeminiPass2,
     getLlmResponse,
     stripAdditionalProperties,
 } from "./llm-client.js";
@@ -39,27 +42,555 @@ function geminiResponse(jsonText, usage) {
     };
 }
 
+/** Helper to build a plain-text Gemini API response (no JSON wrapping)
+ * @param {string} text
+ * @param {{ promptTokenCount?: number, candidatesTokenCount?: number, totalTokenCount?: number }} [usage]
+ */
+function geminiTextResponse(text, usage) {
+    return geminiResponse(text, usage);
+}
+
+/** Helper to set up dual-pass mock: Pass 1 returns text, Pass 2 returns JSON blocks
+ * @param {string} pass1Text
+ * @param {string} pass2Json
+ * @param {{ promptTokenCount?: number, candidatesTokenCount?: number, totalTokenCount?: number }} [pass1Usage]
+ * @param {{ promptTokenCount?: number, candidatesTokenCount?: number, totalTokenCount?: number }} [pass2Usage]
+ */
+function dualPassMock(pass1Text, pass2Json, pass1Usage, pass2Usage) {
+    let callIndex = 0;
+    return () => {
+        callIndex++;
+        if (callIndex === 1) {
+            return Promise.resolve(geminiTextResponse(pass1Text, pass1Usage));
+        }
+        return Promise.resolve(geminiResponse(pass2Json, pass2Usage));
+    };
+}
+
+/** Wrap blocks in scratchpad envelope for dual-pass Pass 2 responses
+ * @param {string} scratchpad
+ * @param {import("../../shared/types.js").MessageBlock[]} blocks
+ */
+function scratchpadEnvelope(scratchpad, blocks) {
+    return JSON.stringify({ internal_reasoning_scratchpad: scratchpad, blocks });
+}
+
 describe("llm-client", () => {
     afterEach(() => {
         mock.restore();
         delete process.env.GOOGLE_AI_API_KEY;
     });
 
-    describe("callGeminiJson", () => {
-        it("returns parsed and validated blocks on happy path", async () => {
+    describe("callGeminiPass1", () => {
+        it("returns raw Markdown text on success", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() => Promise.resolve(geminiTextResponse("Here is a **goblin**.")));
+
+            const result = await callGeminiPass1(
+                [{ role: "user", parts: [{ text: "Tell me about goblins" }] }],
+                "",
+                "gm",
+            );
+
+            expect(result.text).toBe("Here is a **goblin**.");
+            expect(result.usage).toBeUndefined();
+        });
+
+        it("sends correct generationConfig: temperature 0.85, topP 0.95, no JSON mode", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiTextResponse("Some markdown")));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "player");
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+
+            expect(body.generationConfig.temperature).toBe(0.85);
+            expect(body.generationConfig.topP).toBe(0.95);
+            expect(body.generationConfig.maxOutputTokens).toBe(8192);
+            expect(body.generationConfig.responseMimeType).toBeUndefined();
+            expect(body.generationConfig.responseSchema).toBeUndefined();
+        });
+
+        it("uses creative system prompt with step-by-step instructions", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiTextResponse("Markdown")));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "gm");
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            const promptText = body.systemInstruction.parts[0].text;
+
+            expect(promptText).toContain("step-by-step");
+            expect(promptText).toContain("Pathfinder");
+        });
+
+        it("passes conversation contents correctly", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiTextResponse("text")));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const contents = [
+                { role: "user", parts: [{ text: "Hello" }] },
+                { role: "model", parts: [{ text: "Hi there" }] },
+                { role: "user", parts: [{ text: "Tell me about dragons" }] },
+            ];
+
+            await callGeminiPass1(contents, "rag context", "gm");
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+
+            expect(body.contents).toEqual(contents);
+        });
+
+        it("throws RetryableError on 503", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    text: () => Promise.resolve("Service unavailable"),
+                }),
+            );
+
+            try {
+                await callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "player");
+                expect.unreachable("Should have thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(RetryableError);
+                expect(/** @type {Error} */ (error).message).toContain(
+                    "Service temporarily unavailable",
+                );
+            }
+        });
+
+        it("throws rate limit error on 429", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 429,
+                    text: () => Promise.resolve("Rate limit exceeded"),
+                }),
+            );
+
+            expect(
+                callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("Gemini API rate limit exceeded");
+        });
+
+        it("throws descriptive error on other non-OK status", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    text: () => Promise.resolve("Internal Server Error"),
+                }),
+            );
+
+            expect(
+                callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("Gemini API error: 500 Internal Server Error");
+        });
+
+        it("throws when API key is missing", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            expect(
+                callGeminiPass1([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("GOOGLE_AI_API_KEY environment variable is not set");
+        });
+
+        it("returns usage metadata from Gemini response", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const usageMeta = {
+                promptTokenCount: 100,
+                candidatesTokenCount: 50,
+                totalTokenCount: 150,
+            };
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() =>
+                Promise.resolve(geminiTextResponse("Markdown output", usageMeta)),
+            );
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const result = await callGeminiPass1(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.text).toBe("Markdown output");
+            expect(result.usage).toEqual({
+                promptTokenCount: 100,
+                candidatesTokenCount: 50,
+                totalTokenCount: 150,
+            });
+        });
+
+        it("returns usage undefined when metadata missing", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() => Promise.resolve(geminiTextResponse("text")));
+
+            const result = await callGeminiPass1(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.text).toBe("text");
+            expect(result.usage).toBeUndefined();
+        });
+    });
+
+    describe("callGeminiPass2", () => {
+        it("returns parsed blocks from scratchpad-wrapped JSON on success", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const blocks = [
+                { type: "text", markdown: "Hello" },
+                { type: "callout", title: "Rule", markdown: "**Important**" },
+            ];
+            const jsonText = scratchpadEnvelope("Parsing the markdown...", blocks);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            const result = await callGeminiPass2("Pass 1 text here", sanitizedSchema);
+
+            expect(result.blocks).toEqual(blocks);
+            expect(result.usage).toBeUndefined();
+        });
+
+        it("sends correct generationConfig: temperature 0.1, topP 0.5, JSON mode", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const jsonText = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            await callGeminiPass2("some text", sanitizedSchema);
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+
+            expect(body.generationConfig.temperature).toBe(0.1);
+            expect(body.generationConfig.topP).toBe(0.5);
+            expect(body.generationConfig.maxOutputTokens).toBe(8192);
+            expect(body.generationConfig.responseMimeType).toBe("application/json");
+            expect(body.generationConfig.responseSchema).toBeDefined();
+            expect(body.generationConfig.responseSchema.type).toBe("object");
+        });
+
+        it("schema includes internal_reasoning_scratchpad and blocks (withScratchpad=true)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const jsonText = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            await callGeminiPass2("text", sanitizedSchema);
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            const schema = body.generationConfig.responseSchema;
+
+            expect(schema.type).toBe("object");
+            expect(schema.properties.internal_reasoning_scratchpad).toBeDefined();
+            expect(schema.properties.blocks).toBeDefined();
+            expect(schema.required).toContain("internal_reasoning_scratchpad");
+            expect(schema.required).toContain("blocks");
+        });
+
+        it("contents contain Pass 1 text as single user turn", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const jsonText = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            await callGeminiPass2("Pass 1 markdown content", sanitizedSchema);
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+
+            expect(body.contents).toHaveLength(1);
+            expect(body.contents[0].role).toBe("user");
+            expect(body.contents[0].parts[0].text).toBe("Pass 1 markdown content");
+        });
+
+        it("uses extraction system prompt", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const jsonText = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            await callGeminiPass2("text", sanitizedSchema);
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            const promptText = body.systemInstruction.parts[0].text;
+
+            expect(promptText).toContain("JSON transformation engine");
+        });
+
+        it("throws on non-OK HTTP response (503)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    text: () => Promise.resolve("Service unavailable"),
+                }),
+            );
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            try {
+                await callGeminiPass2("text", sanitizedSchema);
+                expect.unreachable("Should have thrown");
+            } catch (error) {
+                expect(error).toBeInstanceOf(RetryableError);
+            }
+        });
+
+        it("throws on non-OK HTTP response (429)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 429,
+                    text: () => Promise.resolve("Rate limited"),
+                }),
+            );
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow(
+                "Gemini API rate limit exceeded",
+            );
+        });
+
+        it("throws on non-OK HTTP response (500)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 500,
+                    text: () => Promise.resolve("Server Error"),
+                }),
+            );
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow(
+                "Gemini API error: 500",
+            );
+        });
+
+        it("throws on malformed JSON in response text", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() => Promise.resolve(geminiResponse("not valid json {")));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow();
+        });
+
+        it("throws on schema validation failure (missing blocks)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve(
+                    geminiResponse(JSON.stringify({ internal_reasoning_scratchpad: "thinking" })),
+                ),
+            );
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow();
+        });
+
+        it("throws on schema validation failure (missing scratchpad)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            mockFetch(() =>
+                Promise.resolve(
+                    geminiResponse(JSON.stringify({ blocks: [{ type: "text", markdown: "Hi" }] })),
+                ),
+            );
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow();
+        });
+
+        it("throws when API key is missing", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+
+            expect(callGeminiPass2("text", sanitizedSchema)).rejects.toThrow(
+                "GOOGLE_AI_API_KEY environment variable is not set",
+            );
+        });
+
+        it("returns empty blocks array if Gemini returns valid scratchpad with empty blocks", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const emptyBlocks = [];
+            const jsonText = scratchpadEnvelope("No blocks needed", emptyBlocks);
+
+            mockFetch(() => Promise.resolve(geminiResponse(jsonText)));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            const result = await callGeminiPass2("text", sanitizedSchema);
+
+            expect(result.blocks).toEqual([]);
+        });
+
+        it("returns usage metadata from Gemini response", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const usageMeta = {
+                promptTokenCount: 200,
+                candidatesTokenCount: 100,
+                totalTokenCount: 300,
+            };
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const jsonText = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(() => Promise.resolve(geminiResponse(jsonText, usageMeta)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const sanitizedSchema = stripAdditionalProperties(rawSchema);
+            const result = await callGeminiPass2("text", sanitizedSchema);
+
+            expect(result.usage).toEqual({
+                promptTokenCount: 200,
+                candidatesTokenCount: 100,
+                totalTokenCount: 300,
+            });
+        });
+    });
+
+    describe("callGeminiJson — dual-pass pipeline", () => {
+        it("makes two fetch calls (one per pass)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Here is a **goblin** warrior.";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const blocks = [{ type: "text", markdown: "Here is a **goblin** warrior." }];
+            const pass2Json = scratchpadEnvelope("Extracting blocks", blocks);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock(pass1Text, pass2Json));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiJson(
+                [{ role: "user", parts: [{ text: "Tell me about goblins" }] }],
+                "",
+                "gm",
+            );
+
+            expect(fetchMock).toHaveBeenCalledTimes(2);
+        });
+
+        it("first call has no JSON mode; second call has JSON mode", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Some markdown";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+            const pass2Json = scratchpadEnvelope("reasoning", singleBlock);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock(pass1Text, pass2Json));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "gm");
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+
+            const pass1Body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            expect(pass1Body.generationConfig.responseMimeType).toBeUndefined();
+            expect(pass1Body.generationConfig.responseSchema).toBeUndefined();
+
+            const pass2Body = JSON.parse(/** @type {string} */ (calls[1][1].body));
+            expect(pass2Body.generationConfig.responseMimeType).toBe("application/json");
+            expect(pass2Body.generationConfig.responseSchema).toBeDefined();
+        });
+
+        it("returns combined blocks from Pass 2", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             /** @type {import("../../shared/types.js").MessageBlock[]} */
             const blocks = [
                 { type: "text", markdown: "Hello Pathfinder!" },
-                {
-                    type: "callout",
-                    title: "Key Rule",
-                    markdown: "**critical hit**",
-                },
+                { type: "callout", title: "Key Rule", markdown: "**critical hit**" },
             ];
 
             /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
+            const fetchMock = mock(
+                dualPassMock("Markdown text", scratchpadEnvelope("reasoning", blocks)),
+            );
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
             const result = await callGeminiJson(
@@ -69,69 +600,48 @@ describe("llm-client", () => {
             );
 
             expect(result.blocks).toEqual(blocks);
-            expect(result.usage).toBeUndefined();
-            expect(fetchMock).toHaveBeenCalled();
         });
 
-        it("sends correct API URL, headers, and request body structure", async () => {
-            process.env.GOOGLE_AI_API_KEY = "my-secret-key";
+        it("aggregates usage metadata across both passes", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
             const blocks = [{ type: "text", markdown: "Test" }];
+            const pass1Usage = {
+                promptTokenCount: 100,
+                candidatesTokenCount: 50,
+                totalTokenCount: 150,
+            };
+            const pass2Usage = {
+                promptTokenCount: 200,
+                candidatesTokenCount: 30,
+                totalTokenCount: 230,
+            };
 
             /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
-
-            await callGeminiJson(
-                [{ role: "user", parts: [{ text: "test message" }] }],
-                "some context",
-                "gm",
-            );
-
-            const calls = /** @type {[string, RequestInit][]} */ (
-                /** @type {unknown} */ (fetchMock.mock.calls)
-            );
-
-            expect(calls[0][0]).toBe(
-                `${GEMINI_API_BASE}/${GEMINI_MODEL}:generateContent?key=my-secret-key`,
-            );
-
-            const opts = calls[0][1];
-            expect(opts.method).toBe("POST");
-            expect(opts.headers).toEqual({
-                "Content-Type": "application/json",
-            });
-
-            const body = JSON.parse(/** @type {string} */ (opts.body));
-            expect(body.contents).toHaveLength(1);
-            expect(body.contents[0].role).toBe("user");
-            expect(body.contents[0].parts[0].text).toBe("test message");
-            expect(body.generationConfig.responseMimeType).toBe("application/json");
-            expect(body.generationConfig.responseSchema).toBeDefined();
-            expect(body.generationConfig.responseSchema.type).toBe("array");
-        });
-
-        it("includes repetition-prevention parameters in generationConfig", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            const blocks = [{ type: "text", markdown: "Test" }];
-
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
-
-            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
-
-            const body = JSON.parse(
-                /** @type {string} */ (
-                    /** @type {[string, RequestInit][]} */ (
-                        /** @type {unknown} */ (fetchMock.mock.calls)
-                    )[0][1].body
+            const fetchMock = mock(
+                dualPassMock(
+                    "Markdown",
+                    scratchpadEnvelope("reasoning", blocks),
+                    pass1Usage,
+                    pass2Usage,
                 ),
             );
-            expect(body.generationConfig.temperature).toBe(0.7);
-            expect(body.generationConfig.topP).toBe(0.9);
-            expect(body.generationConfig.maxOutputTokens).toBe(8192);
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.usage).toEqual({
+                promptTokenCount: 300,
+                candidatesTokenCount: 80,
+                totalTokenCount: 380,
+            });
         });
 
-        it("throws descriptive error on non-OK HTTP response", async () => {
+        it("Pass 1 error (non-retryable) propagates up", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             mockFetch(() =>
                 Promise.resolve({
@@ -146,22 +656,7 @@ describe("llm-client", () => {
             ).rejects.toThrow("Gemini API error: 500 Internal Server Error");
         });
 
-        it("throws with rate limit message on 429", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            mockFetch(() =>
-                Promise.resolve({
-                    ok: false,
-                    status: 429,
-                    text: () => Promise.resolve("Rate limit exceeded"),
-                }),
-            );
-
-            expect(
-                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
-            ).rejects.toThrow("Gemini API rate limit exceeded");
-        });
-
-        it("throws RetryableError on 503", async () => {
+        it("Pass 1 RetryableError propagates up (triggers retry loop)", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             mockFetch(() =>
                 Promise.resolve({
@@ -176,15 +671,25 @@ describe("llm-client", () => {
                 expect.unreachable("Should have thrown");
             } catch (error) {
                 expect(error).toBeInstanceOf(RetryableError);
-                expect(/** @type {Error} */ (error).message).toContain(
-                    "Service temporarily unavailable",
-                );
             }
         });
 
-        it("falls back to text block on malformed JSON in response", async () => {
+        it("Pass 2 HTTP error (503) falls back to Pass 1 text as text block, does NOT throw RetryableError", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
-            mockFetch(() => Promise.resolve(geminiResponse("not valid json {")));
+            const pass1Text = "Here is a goblin warrior.";
+
+            let callIndex = 0;
+            mockFetch(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve(geminiTextResponse(pass1Text));
+                }
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    text: () => Promise.resolve("Service unavailable"),
+                });
+            });
 
             const result = await callGeminiJson(
                 [{ role: "user", parts: [{ text: "test" }] }],
@@ -192,16 +697,25 @@ describe("llm-client", () => {
                 "player",
             );
 
-            expect(result).toEqual({
-                blocks: [{ type: "text", markdown: "not valid json {" }],
-                usage: undefined,
-            });
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
         });
 
-        it("falls back to text block on Zod validation failure", async () => {
+        it("Pass 2 HTTP error (429) falls back to Pass 1 text as text block, does NOT throw", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
-            const invalidBlocks = [{ type: "unknown-type", foo: "bar" }];
-            mockFetch(() => Promise.resolve(geminiResponse(JSON.stringify(invalidBlocks))));
+            const pass1Text = "Some creative output.";
+
+            let callIndex = 0;
+            mockFetch(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve(geminiTextResponse(pass1Text));
+                }
+                return Promise.resolve({
+                    ok: false,
+                    status: 429,
+                    text: () => Promise.resolve("Rate limited"),
+                });
+            });
 
             const result = await callGeminiJson(
                 [{ role: "user", parts: [{ text: "test" }] }],
@@ -209,99 +723,21 @@ describe("llm-client", () => {
                 "player",
             );
 
-            expect(result).toEqual({
-                blocks: [
-                    {
-                        type: "text",
-                        markdown:
-                            "The AI produced a response that couldn't be displayed properly. Please try rephrasing your question or starting a new conversation.",
-                    },
-                ],
-                usage: undefined,
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
+        });
+
+        it("Pass 2 JSON parse error falls back to Pass 1 text as text block", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Creative markdown content.";
+
+            let callIndex = 0;
+            mockFetch(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve(geminiTextResponse(pass1Text));
+                }
+                return Promise.resolve(geminiResponse("not valid json {"));
             });
-        });
-
-        it("throws when API key is missing", async () => {
-            delete process.env.GOOGLE_AI_API_KEY;
-
-            expect(
-                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
-            ).rejects.toThrow("GOOGLE_AI_API_KEY environment variable is not set");
-        });
-
-        it("sends system instruction in request body", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            const blocks = [{ type: "text", markdown: "Test" }];
-
-            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
-
-            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
-
-            const calls = /** @type {[string, RequestInit][]} */ (
-                /** @type {unknown} */ (fetchMock.mock.calls)
-            );
-            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
-
-            expect(body.systemInstruction).toBeDefined();
-            expect(body.systemInstruction.parts[0].text).toContain("Pathfinder");
-        });
-
-        it("passes ungrounded flag to system prompt", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            const blocks = [{ type: "text", markdown: "Test" }];
-
-            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
-
-            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player", true);
-
-            const calls = /** @type {[string, RequestInit][]} */ (
-                /** @type {unknown} */ (fetchMock.mock.calls)
-            );
-            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
-            const promptText = body.systemInstruction.parts[0].text;
-
-            expect(promptText).toContain("No Reference Data Available");
-        });
-
-        it("sends mode-aware prompt (player vs gm)", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            const blocks = [{ type: "text", markdown: "Test" }];
-
-            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
-
-            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
-            const playerCalls = /** @type {[string, RequestInit][]} */ (
-                /** @type {unknown} */ (fetchMock.mock.calls)
-            );
-            const playerBody = JSON.parse(/** @type {string} */ (playerCalls[0][1].body));
-            const playerPrompt = playerBody.systemInstruction.parts[0].text;
-
-            mock.restore();
-            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock2 = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
-            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock2));
-
-            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "gm");
-            const gmCalls = /** @type {[string, RequestInit][]} */ (
-                /** @type {unknown} */ (fetchMock2.mock.calls)
-            );
-            const gmBody = JSON.parse(/** @type {string} */ (gmCalls[0][1].body));
-            const gmPrompt = gmBody.systemInstruction.parts[0].text;
-
-            expect(playerPrompt).toContain("advising a player");
-            expect(gmPrompt).toContain("advising a Game Master");
-            expect(playerPrompt).not.toBe(gmPrompt);
-        });
-
-        it("falls back to text block on empty array from Gemini", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            mockFetch(() => Promise.resolve(geminiResponse("[]")));
 
             const result = await callGeminiJson(
                 [{ role: "user", parts: [{ text: "test" }] }],
@@ -309,30 +745,136 @@ describe("llm-client", () => {
                 "player",
             );
 
-            expect(result).toEqual({
-                blocks: [
-                    {
-                        type: "text",
-                        markdown: "I couldn't generate a response. Please try again.",
-                    },
-                ],
-                usage: undefined,
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
+        });
+
+        it("Pass 2 Zod validation error falls back to Pass 1 text as text block", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Some content from Pass 1.";
+
+            let callIndex = 0;
+            mockFetch(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve(geminiTextResponse(pass1Text));
+                }
+                return Promise.resolve(
+                    geminiResponse(JSON.stringify({ blocks: [{ type: "unknown" }] })),
+                );
+            });
+
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
+        });
+
+        it("Pass 2 returns empty blocks array falls back to Pass 1 text as text block", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Great markdown content.";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const emptyBlocks = [];
+            const pass2Json = scratchpadEnvelope("reasoning", emptyBlocks);
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock(pass1Text, pass2Json));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
+        });
+
+        it("Pass 1 succeeds, Pass 2 succeeds — returns Pass 2 blocks with aggregated usage", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Markdown content";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const blocks = [
+                { type: "text", markdown: "Extracted text" },
+                { type: "callout", title: "Rule", markdown: "Info" },
+            ];
+            const pass2Json = scratchpadEnvelope("reasoning", blocks);
+            const pass1Usage = {
+                promptTokenCount: 100,
+                candidatesTokenCount: 50,
+                totalTokenCount: 150,
+            };
+            const pass2Usage = {
+                promptTokenCount: 80,
+                candidatesTokenCount: 40,
+                totalTokenCount: 120,
+            };
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock(pass1Text, pass2Json, pass1Usage, pass2Usage));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.blocks).toEqual(blocks);
+            expect(result.usage).toEqual({
+                promptTokenCount: 180,
+                candidatesTokenCount: 90,
+                totalTokenCount: 270,
             });
         });
 
-        it("returns usage metadata from Gemini response", async () => {
+        it("fallback response includes Pass 1 usage metadata (not undefined)", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            const pass1Text = "Content";
+            const pass1Usage = {
+                promptTokenCount: 50,
+                candidatesTokenCount: 25,
+                totalTokenCount: 75,
+            };
+
+            let callIndex = 0;
+            mockFetch(() => {
+                callIndex++;
+                if (callIndex === 1) {
+                    return Promise.resolve(geminiTextResponse(pass1Text, pass1Usage));
+                }
+                return Promise.resolve(geminiResponse("bad json"));
+            });
+
+            const result = await callGeminiJson(
+                [{ role: "user", parts: [{ text: "test" }] }],
+                "",
+                "player",
+            );
+
+            expect(result.blocks).toEqual([{ type: "text", markdown: pass1Text }]);
+            expect(result.usage).toEqual({
+                promptTokenCount: 50,
+                candidatesTokenCount: 25,
+                totalTokenCount: 75,
+            });
+        });
+
+        it("returns usage from available pass when only one has metadata", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             /** @type {import("../../shared/types.js").MessageBlock[]} */
             const blocks = [{ type: "text", markdown: "Test" }];
-            const usageMeta = {
+            const pass1Usage = {
                 promptTokenCount: 100,
                 candidatesTokenCount: 50,
                 totalTokenCount: 150,
             };
 
             /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() =>
-                Promise.resolve(geminiResponse(JSON.stringify(blocks), usageMeta)),
+            const fetchMock = mock(
+                dualPassMock("text", scratchpadEnvelope("reasoning", blocks), pass1Usage),
             );
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
@@ -350,29 +892,190 @@ describe("llm-client", () => {
             });
         });
 
-        it("returns usage undefined when usageMetadata missing from response", async () => {
+        it("throws when API key is missing", async () => {
+            delete process.env.GOOGLE_AI_API_KEY;
+
+            expect(
+                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
+            ).rejects.toThrow("GOOGLE_AI_API_KEY environment variable is not set");
+        });
+
+        it("sends mode-aware prompt in Pass 1", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
             /** @type {import("../../shared/types.js").MessageBlock[]} */
-            const blocks = [{ type: "text", markdown: "Test" }];
+            const singleBlock = [{ type: "text", markdown: "Test" }];
 
-            mockFetch(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock("text", scratchpadEnvelope("r", singleBlock)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
-            const result = await callGeminiJson(
-                [{ role: "user", parts: [{ text: "test" }] }],
-                "",
-                "player",
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
+            const playerCalls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
             );
+            const playerBody = JSON.parse(/** @type {string} */ (playerCalls[0][1].body));
+            const playerPrompt = playerBody.systemInstruction.parts[0].text;
 
-            expect(result.blocks).toEqual(blocks);
-            expect(result.usage).toBeUndefined();
+            expect(playerPrompt).toContain("advising a player");
+        });
+
+        it("passes ungrounded flag to Pass 1 system prompt", async () => {
+            process.env.GOOGLE_AI_API_KEY = "test-key";
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
+
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock("text", scratchpadEnvelope("r", singleBlock)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
+
+            await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player", true);
+
+            const calls = /** @type {[string, RequestInit][]} */ (
+                /** @type {unknown} */ (fetchMock.mock.calls)
+            );
+            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            const promptText = body.systemInstruction.parts[0].text;
+
+            expect(promptText).toContain("No Reference Data Available");
+        });
+    });
+
+    describe("buildGeminiResponseSchema — withScratchpad", () => {
+        it("default (no options) returns array schema (backward compat)", () => {
+            const schema = buildGeminiResponseSchema();
+            expect(schema.type).toBe("array");
+        });
+
+        it("{ withScratchpad: true } returns object with internal_reasoning_scratchpad and blocks", () => {
+            const schema = buildGeminiResponseSchema({ withScratchpad: true });
+            expect(schema.type).toBe("object");
+            const props = /** @type {Record<string, unknown>} */ (schema.properties);
+            expect(props.internal_reasoning_scratchpad).toBeDefined();
+            expect(props.blocks).toBeDefined();
+        });
+
+        it("scratchpad schema has type string and is in required array", () => {
+            const schema = buildGeminiResponseSchema({ withScratchpad: true });
+            const props = /** @type {Record<string, unknown>} */ (schema.properties);
+            const scratchpad = /** @type {Record<string, unknown>} */ (
+                props.internal_reasoning_scratchpad
+            );
+            expect(scratchpad.type).toBe("string");
+            const required = /** @type {string[]} */ (schema.required);
+            expect(required).toContain("internal_reasoning_scratchpad");
+        });
+
+        it("blocks schema is identical to the non-scratchpad version", () => {
+            const arraySchema = buildGeminiResponseSchema();
+            const objectSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const props = /** @type {Record<string, unknown>} */ (objectSchema.properties);
+            const blocks = /** @type {Record<string, unknown>} */ (props.blocks);
+            expect(blocks).toEqual(arraySchema);
+        });
+
+        it("sanitized scratchpad schema has no additionalProperties", () => {
+            const rawSchema = buildGeminiResponseSchema({ withScratchpad: true });
+            const schema = stripAdditionalProperties(rawSchema);
+
+            /** @param {unknown} node */
+            function hasAdditionalProperties(node) {
+                if (node === null || node === undefined || typeof node !== "object") {
+                    return false;
+                }
+                if (Array.isArray(node)) {
+                    return node.some(hasAdditionalProperties);
+                }
+                const obj = /** @type {Record<string, unknown>} */ (node);
+                for (const key of Object.keys(obj)) {
+                    if (key === "additionalProperties") {
+                        return true;
+                    }
+                    if (hasAdditionalProperties(obj[key])) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            expect(hasAdditionalProperties(schema)).toBe(false);
+        });
+
+        it("required array includes both internal_reasoning_scratchpad and blocks", () => {
+            const schema = buildGeminiResponseSchema({ withScratchpad: true });
+            const required = /** @type {string[]} */ (schema.required);
+            expect(required).toEqual(["internal_reasoning_scratchpad", "blocks"]);
+        });
+    });
+
+    describe("buildCreativeSystemPrompt", () => {
+        it("includes step-by-step reasoning instruction", () => {
+            const prompt = buildCreativeSystemPrompt("", "gm");
+            expect(prompt).toContain("step-by-step");
+        });
+
+        it("includes RAG context when provided", () => {
+            const prompt = buildCreativeSystemPrompt("Mitflit King is a CR 1 creature", "gm");
+            expect(prompt).toContain("Mitflit King");
+        });
+
+        it("omits RAG section when context is empty", () => {
+            const prompt = buildCreativeSystemPrompt("", "gm");
+            expect(prompt).not.toContain("Reference Data\n\n");
+        });
+
+        it("includes player restrictions when mode is player", () => {
+            const prompt = buildCreativeSystemPrompt("", "player");
+            expect(prompt).toContain("Player Mode Restrictions");
+            expect(prompt).toContain("NEVER reveal creature mechanics");
+        });
+
+        it("omits player restrictions when mode is gm", () => {
+            const prompt = buildCreativeSystemPrompt("", "gm");
+            expect(prompt).not.toContain("Player Mode Restrictions");
+        });
+
+        it("includes ungrounded warning when ungrounded=true", () => {
+            const prompt = buildCreativeSystemPrompt("", "gm", true);
+            expect(prompt).toContain("No Reference Data Available");
+        });
+
+        it("does NOT mention JSON output format", () => {
+            const prompt = buildCreativeSystemPrompt("", "gm");
+            expect(prompt).not.toContain("JSON array");
+            expect(prompt).not.toContain("responseMimeType");
+        });
+    });
+
+    describe("buildExtractionSystemPrompt", () => {
+        it("instructs JSON output with scratchpad + blocks structure", () => {
+            const prompt = buildExtractionSystemPrompt();
+            expect(prompt).toContain("internal_reasoning_scratchpad");
+            expect(prompt).toContain("blocks");
+        });
+
+        it("includes block type descriptions", () => {
+            const prompt = buildExtractionSystemPrompt();
+            expect(prompt).toContain("text");
+            expect(prompt).toContain("callout");
+            expect(prompt).toContain("stat-block");
+            expect(prompt).toContain("custom-stat-block");
+            expect(prompt).toContain("rule-detail");
+        });
+
+        it("does NOT include RAG context (not relevant for parsing)", () => {
+            const prompt = buildExtractionSystemPrompt();
+            expect(prompt).not.toContain("Reference Data");
+        });
+
+        it("mentions strict parsing role", () => {
+            const prompt = buildExtractionSystemPrompt();
+            expect(prompt).toContain("JSON transformation engine");
         });
     });
 
     describe("getLlmResponse", () => {
         it("throws on non-retryable error when ENABLE_MOCK_FALLBACK is unset", async () => {
-            // No API key → callGeminiJson throws immediately → getLlmResponse should throw
             delete process.env.GOOGLE_AI_API_KEY;
-            // Ensure env var is not set
             delete process.env.ENABLE_MOCK_FALLBACK;
 
             try {
@@ -412,7 +1115,9 @@ describe("llm-client", () => {
                 { type: "text", markdown: "Real response" },
                 { type: "callout", title: "Note", markdown: "Important" },
             ];
-            mockFetch(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
+            /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
+            const fetchMock = mock(dualPassMock("Markdown", scratchpadEnvelope("r", blocks)));
+            globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
             const result = await getLlmResponse(
                 [{ role: "user", parts: [{ text: "test" }] }],
@@ -471,7 +1176,6 @@ describe("llm-client", () => {
                 },
             };
             const result = stripAdditionalProperties(schema);
-            // Walk result to ensure no additionalProperties anywhere
             /** @param {Record<string, unknown>} obj */
             function walk(obj) {
                 for (const [key, value] of Object.entries(obj)) {
@@ -482,7 +1186,6 @@ describe("llm-client", () => {
                 }
             }
             walk(result);
-            // Verify structure preserved (skills still exists)
             const props = /** @type {Record<string, unknown>} */ (result.properties);
             const data = /** @type {Record<string, unknown>} */ (props.data);
             const dataProps = /** @type {Record<string, unknown>} */ (data.properties);
@@ -567,7 +1270,6 @@ describe("llm-client", () => {
 
             expect(schema.type).toBe("array");
             expect(items.anyOf).toHaveLength(5);
-            // Check required fields survived
             const customBlock = /** @type {Record<string, unknown>} */ (items.anyOf[2]);
             const props = /** @type {Record<string, unknown>} */ (customBlock.properties);
             const data = /** @type {Record<string, unknown>} */ (props.data);
@@ -578,10 +1280,11 @@ describe("llm-client", () => {
     describe("callGeminiJson — sanitization", () => {
         it("request body contains no additionalProperties in responseSchema", async () => {
             process.env.GOOGLE_AI_API_KEY = "test-key";
-            const blocks = [{ type: "text", markdown: "Test" }];
+            /** @type {import("../../shared/types.js").MessageBlock[]} */
+            const singleBlock = [{ type: "text", markdown: "Test" }];
 
             /** @type {import("bun:test").Mock<() => Promise<unknown>>} */
-            const fetchMock = mock(() => Promise.resolve(geminiResponse(JSON.stringify(blocks))));
+            const fetchMock = mock(dualPassMock("text", scratchpadEnvelope("r", singleBlock)));
             globalThis.fetch = /** @type {typeof fetch} */ (/** @type {unknown} */ (fetchMock));
 
             await callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player");
@@ -589,7 +1292,7 @@ describe("llm-client", () => {
             const calls = /** @type {[string, RequestInit][]} */ (
                 /** @type {unknown} */ (fetchMock.mock.calls)
             );
-            const body = JSON.parse(/** @type {string} */ (calls[0][1].body));
+            const pass2Body = JSON.parse(/** @type {string} */ (calls[1][1].body));
 
             /** @param {unknown} node */
             function hasAdditionalProperties(node) {
@@ -614,24 +1317,7 @@ describe("llm-client", () => {
                 return false;
             }
 
-            expect(hasAdditionalProperties(body.generationConfig.responseSchema)).toBe(false);
-        });
-    });
-
-    describe("callGeminiJson — 400 error handling", () => {
-        it("400 error from Gemini throws descriptive error", async () => {
-            process.env.GOOGLE_AI_API_KEY = "test-key";
-            mockFetch(() =>
-                Promise.resolve({
-                    ok: false,
-                    status: 400,
-                    text: () => Promise.resolve("Invalid JSON payload received"),
-                }),
-            );
-
-            expect(
-                callGeminiJson([{ role: "user", parts: [{ text: "test" }] }], "", "player"),
-            ).rejects.toThrow("Gemini API error: 400 Invalid JSON payload received");
+            expect(hasAdditionalProperties(pass2Body.generationConfig.responseSchema)).toBe(false);
         });
     });
 
@@ -816,8 +1502,6 @@ describe("llm-client", () => {
 
             expect(text.required).toEqual(["type", "markdown"]);
             expect(callout.required).toEqual(["type", "title", "markdown"]);
-            // title is intentionally NOT required — Gemini sometimes omits it when
-            // anyOf schemas share ruleItemId; resolveStatBlock falls back to the DB name.
             expect(statBlock.required).toEqual(["type", "ruleItemId"]);
             expect(customStatBlock.required).toEqual(["type", "title", "data"]);
             expect(ruleDetail.required).toEqual(["type", "ruleItemId"]);

--- a/shared/schemas.js
+++ b/shared/schemas.js
@@ -341,6 +341,11 @@ const messageBlockSchema = z.union([
 
 const messageBlocksArraySchema = z.array(messageBlockSchema);
 
+const dualPassResponseSchema = z.object({
+    internal_reasoning_scratchpad: z.string(),
+    blocks: messageBlocksArraySchema,
+});
+
 // --- Gemini API response schema for summarization validation ---
 
 const usageMetadataSchema = z
@@ -403,6 +408,7 @@ export {
     ruleDetailBlockSchema,
     messageBlockSchema,
     messageBlocksArraySchema,
+    dualPassResponseSchema,
     geminiResponseSchema,
     apiKeyStatusSchema,
 };

--- a/shared/schemas.test.js
+++ b/shared/schemas.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { customStatBlockSchema, messageBlockSchema } from "./schemas.js";
+import { customStatBlockSchema, dualPassResponseSchema, messageBlockSchema } from "./schemas.js";
 
 describe("customStatBlockSchema", () => {
     it("validates a minimal valid block with name and level only", () => {
@@ -152,5 +152,48 @@ describe("messageBlockSchema union", () => {
     it("still accepts rule-detail blocks", () => {
         const block = { type: /** @type {const} */ ("rule-detail"), ruleItemId: "abc-123" };
         expect(messageBlockSchema.parse(block)).toEqual(block);
+    });
+});
+
+describe("dualPassResponseSchema", () => {
+    it("validates a valid response with scratchpad and blocks", () => {
+        const response = {
+            internal_reasoning_scratchpad: "Thinking about the creature...",
+            blocks: [
+                { type: /** @type {const} */ ("text"), markdown: "Here is a goblin." },
+                { type: /** @type {const} */ ("stat-block"), ruleItemId: "abc-123" },
+            ],
+        };
+        expect(dualPassResponseSchema.parse(response)).toEqual(response);
+    });
+
+    it("rejects response missing internal_reasoning_scratchpad", () => {
+        const response = {
+            blocks: [{ type: /** @type {const} */ ("text"), markdown: "Hello" }],
+        };
+        expect(() => dualPassResponseSchema.parse(response)).toThrow();
+    });
+
+    it("rejects response missing blocks", () => {
+        const response = {
+            internal_reasoning_scratchpad: "Some reasoning",
+        };
+        expect(() => dualPassResponseSchema.parse(response)).toThrow();
+    });
+
+    it("rejects response with invalid block types inside blocks", () => {
+        const response = {
+            internal_reasoning_scratchpad: "Reasoning",
+            blocks: [{ type: "unknown-type", foo: "bar" }],
+        };
+        expect(() => dualPassResponseSchema.parse(response)).toThrow();
+    });
+
+    it("accepts response with empty blocks array", () => {
+        const response = {
+            internal_reasoning_scratchpad: "No blocks needed",
+            blocks: [],
+        };
+        expect(dualPassResponseSchema.parse(response)).toEqual(response);
     });
 });


### PR DESCRIPTION
## Summary

- **Dual-pass Gemini pipeline**: Refactors LLM call architecture into two sequential passes — Pass 1 (creative, high temp, free Markdown) followed by Pass 2 (structural, low temp, strict JSON extraction)
- **Schema safeguard**: Adds `internal_reasoning_scratchpad` field to JSON response schema, giving Gemini a dedicated reasoning outlet to prevent thinking data from leaking into structured fields
- **Graceful fallback**: All Pass 2 errors are caught at the orchestrator level and fall back to wrapping Pass 1 text in a text block, ensuring users always see content

Closes #115

## Test plan

- [x] 800 unit tests pass (56 new tests for dual-pass pipeline)
- [x] `bun run check` — no type errors
- [x] `bunx oxlint .` — 0 warnings, 0 errors
- [x] `bunx oxfmt . --check` — all formatted correctly
- [x] Backward compatible — `callGeminiJson()` signature and return type unchanged