### PR TITLE
perf: shrink docker image and cache CI dependencies

### DIFF
--- a/.changeset/docker-ci-optimize.md
+++ b/.changeset/docker-ci-optimize.md
@@ -1,0 +1,5 @@
+---
+bump: patch
+---
+
+Optimize production Docker image to a scratch-based single Bun-compiled binary with build-less static assets, and speed up CI via Playwright browser caching and buildx gha layer caching.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,24 @@
+# Preserve the original entry plus the expanded ignore list (PLAN.md §4.1).
+# Critical files kept in context: server/, shared/, client/, scripts/,
+# package.json, bun.lock, bunfig.toml, jsconfig.json, globals.d.ts,
+# data/localizations.json (only data/*.sqlite* DBs are ignored).
 .env
+.env.test
+node_modules
+.git
+.github
+.vscode
+.agents
+.opencode
+dist
+temp
+test-results
+test
+vrtests
+playwright-report
+data/*.sqlite*
+Dockerfile
+.dockerignore
+docker-compose*.yml
+docs
+*.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,21 +87,35 @@ jobs:
 
     e2e:
         runs-on: ubuntu-latest
-        container:
-            image: mcr.microsoft.com/playwright:v1.59.1-noble
-            options: --user root
+        env:
+            NODE_ENV: test
         steps:
             - uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.ref || github.ref }}
-            - name: Prepare Container
-              run: apt-get update && apt-get install -y unzip
             - uses: oven-sh/setup-bun@v2
             - uses: actions/cache@v4
               with:
                   path: ~/.bun/install/cache
                   key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
             - run: bun install --frozen-lockfile
+            # Browser binaries are owned by the bare `playwright` package (not
+            # @playwright/test), so key the cache on its declared version. jq
+            # is preinstalled on ubuntu-latest (PLAN.md §3.8).
+            - name: Playwright version
+              id: pw
+              run: echo "v=$(jq -r .version node_modules/playwright/package.json)" >> "$GITHUB_OUTPUT"
+            - name: Cache browsers
+              id: pw-cache
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: pw-${{ runner.os }}-${{ steps.pw.outputs.v }}
+            - name: Install system deps
+              run: bun x playwright install-deps
+            - name: Install browsers (cache miss only)
+              if: steps.pw-cache.outputs.cache-hit != 'true'
+              run: bun x playwright install
             - name: Run Playwright tests
               run: bun run e2e
             - name: Upload Playwright Report

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -18,14 +18,26 @@ jobs:
               run: |
                   echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
-            - name: Log in to GHCR
-              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
+            - uses: oven-sh/setup-bun@v2
+            - uses: actions/cache@v4
+              with:
+                  path: ~/.bun/install/cache
+                  key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+            - run: bun install --frozen-lockfile
+            - uses: docker/setup-buildx-action@v3
+            - uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
             - name: Build and Push
-              run: |
-                  IMAGE_ID=ghcr.io/${{ env.REPO_LOWER }}:latest
-                  docker build . -t $IMAGE_ID
-                  docker push $IMAGE_ID
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  tags: ghcr.io/${{ env.REPO_LOWER }}:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
             - name: Install SSH Key
               uses: shimataro/ssh-key-action@v2
               with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,6 +18,14 @@ jobs:
               run: |
                   echo "REPO_LOWER=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
 
+            - uses: oven-sh/setup-bun@v2
+            - uses: actions/cache@v4
+              with:
+                  path: ~/.bun/install/cache
+                  key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+            - run: bun install --frozen-lockfile
+            - uses: docker/setup-buildx-action@v3
+
             # 2. Login to GHCR
             - name: Login to GHCR
               uses: docker/login-action@v3
@@ -33,6 +41,8 @@ jobs:
                   push: true
                   # Note the use of env.REPO_LOWER here
                   tags: ghcr.io/${{ env.REPO_LOWER }}:pr-${{ github.event.number }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
             # 4. Setup SSH for Context
             - name: Install SSH Key

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # carries compile fixes vs the 1.1 baseline in the original issue.
 FROM oven/bun:1.3-slim AS builder
 WORKDIR /app
+# oven/bun:*-slim (Debian-slim) does NOT ship /etc/ssl/certs/ca-certificates.crt
+# by default. Install the bundle here so the runtime stage can COPY it for TLS
+# verification of outbound HTTPS (Google AI). PLAN.md §3.5.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,44 @@
-# Oven/bun ships bun:sqlite built-in; the main DB (data/dev.sqlite) uses it.
-# Vector search is served by the Qdrant sidecar (see docker-compose.yml);
-# indexing writes directly to Qdrant via `bun run create:embeddings`.
-FROM oven/bun:latest
+# ---- Stage 1: builder ----
+# Pin to 1.3-slim to match the local Bun 1.3.x toolchain (PLAN.md §3.6); 1.3
+# carries compile fixes vs the 1.1 baseline in the original issue.
+FROM oven/bun:1.3-slim AS builder
 WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
 COPY . .
-RUN bun install
+# Embeds the runtime + module graph (incl. scripts/lib/vector-math.js,
+# server/db/migrate.js) into a single native binary. --sourcemap is dropped
+# (PLAN.md §4.3 notes): it inflates the binary several MB and the scratch
+# runtime has no tooling to consume it.
+RUN bun build ./server/index.js --compile --minify --outfile dist/server-binary
+
+# ---- Stage 2: minimal runtime ----
+# scratch has no shell, no package manager, no node_modules — only the compiled
+# binary + static assets + TLS root certs.
+FROM scratch
+WORKDIR /app
+# TLS root certs for outbound HTTPS (Google AI). scratch has no standard
+# discovery paths, so SSL_CERT_FILE / NODE_EXTRA_CA_CERTS are pinned below.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Standalone backend engine.
+COPY --from=builder /app/dist/server-binary ./server
+# Build-less frontend + shared schemas + localization seed.
+COPY ./client ./client
+COPY ./shared ./shared
+COPY ./data/localizations.json ./data/localizations.json
+# Required at boot: server/index.js readFileSync()s package.json via
+# process.cwd() (PLAN.md §3.2/§4.3) and throws if absent.
+COPY ./package.json ./package.json
+
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+ENV NODE_ENV=production
+
+# SQLite writes go here (DB path is process.cwd()-relative → /app/data/dev.sqlite).
+# Compose mounts the app_data named volume over this; the anonymous volume is
+# the fallback for plain `docker run`.
+VOLUME /app/data
 EXPOSE 3000
-CMD ["bun", "run", "serve"]
+# exec-form (no shell) — required since scratch has no shell. `bun build
+# --compile` emits a chmod +x binary and COPY preserves the mode.
+CMD ["./server"]

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,13 @@
 ## CI / Workflows
 
+### e2e job runtime
+
+The `e2e` job runs on the host `ubuntu-latest` runner (not the
+`mcr.microsoft.com/playwright` container). Browsers are cached keyed on the
+`playwright` package version (`~/.cache/ms-playwright`); `playwright install`
+only runs on a cache miss. The job sets `NODE_ENV: test` so the
+`/api/test/*` seed endpoints used by VR `global-setup.js` are available.
+
 ### Updating Playwright visual-regression snapshots
 
 When a CI run fails on the `e2e` job because snapshots are outdated, use the **Update Snapshots** workflow:

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
@@ -46,7 +46,11 @@ vectorStore
     });
 
 // --- Read package.json version at module load ---
-const packageJsonPath = fileURLToPath(new URL("../package.json", import.meta.url));
+// Resolve via process.cwd() so the path works both in dev (repo root) and
+// inside a `bun build --compile` binary where import.meta.url points at the
+// executable, not the source tree. WORKDIR /app in the container guarantees
+// process.cwd() === "/app" (see Dockerfile).
+const packageJsonPath = resolve(process.cwd(), "package.json");
 const packageJson = /** @type {{ version: string }} */ (
     JSON.parse(readFileSync(packageJsonPath, "utf-8"))
 );
@@ -157,9 +161,11 @@ if (process.env.NODE_ENV !== "production") {
 // Everything else gets index.html so deep links like
 // /conversations/:uuid load the SPA correctly.
 
-// Resolve paths relative to this module's directory (server/)
-// to avoid working-directory mismatches in deployed environments.
-const clientDir = import.meta.dir + "/../client";
+// Resolve paths relative to the app root (process.cwd()) so static serving
+// works identically in dev (repo root) and inside a `bun build --compile`
+// binary on the scratch runtime (WORKDIR /app). import.meta.dir would point
+// at the executable's own location in the compiled binary.
+const clientDir = resolve(process.cwd(), "client");
 
 /** @type {string | null} */
 let _indexHtml = null;

--- a/test/server/path-resolution.test.js
+++ b/test/server/path-resolution.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Guards the `process.cwd()`-based path resolution introduced in
+ * `server/index.js` so the package.json read and the client/ static root keep
+ * working both in dev (repo root) and inside a `bun build --compile` binary
+ * (where `import.meta.dir`/`import.meta.url` resolve to the executable's
+ * location, not the source tree).
+ *
+ * See PLAN.md §3.2 / §4.2.
+ */
+
+describe("server path resolution (process.cwd-based)", () => {
+    it("resolves package.json via process.cwd() to the same file as import.meta.url", () => {
+        // What the OLD code did (breaks inside a compiled binary):
+        const metaPath = fileURLToPath(new URL("../../package.json", import.meta.url));
+        // What the NEW code does (works in dev + scratch container WORKDIR /app):
+        const cwdPath = resolve(process.cwd(), "package.json");
+
+        expect(existsSync(cwdPath)).toBe(true);
+        expect(resolve(cwdPath)).toBe(resolve(metaPath));
+    });
+
+    it("reads the same version from the cwd-resolved package.json", () => {
+        const cwdPath = resolve(process.cwd(), "package.json");
+        const pkg = JSON.parse(readFileSync(cwdPath, "utf-8"));
+
+        expect(pkg.version).toMatch(/^\d+\.\d+\.\d+$/);
+    });
+
+    it("resolves the client dir via process.cwd() and it contains index.html", () => {
+        // Mirrors `const clientDir = resolve(process.cwd(), "client")` in server/index.js
+        const clientDir = resolve(process.cwd(), "client");
+
+        expect(existsSync(clientDir)).toBe(true);
+        expect(existsSync(resolve(clientDir, "index.html"))).toBe(true);
+        expect(existsSync(resolve(clientDir, "manifest.webmanifest"))).toBe(true);
+    });
+
+    it("resolves the localizations seed via process.cwd()", () => {
+        // foundry-refs.js#loadLocalizations reads process.cwd()/data/localizations.json.
+        // Guarded here because the new .dockerignore keeps this file in context.
+        const locPath = resolve(process.cwd(), "data", "localizations.json");
+
+        expect(existsSync(locPath)).toBe(true);
+        const contents = readFileSync(locPath, "utf-8");
+        expect(contents.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #116 — optimizes the Docker production image and CI/CD pipelines.

- **Multi-stage Dockerfile**: `oven/bun:1.3-slim` builder compiles `server/index.js` to a standalone binary (`bun build --compile --minify`); `scratch` runtime ships only the binary + static `client/`/`shared/`/`data/localizations.json` assets + SSL CA bundle. Expected footprint drops to ~55–95 MB (Bun binary alone is 50–90 MB).
- **`server/index.js`**: `import.meta.url`/`import.meta.dir` → `process.cwd()`-based resolution, so the compiled binary can locate `package.json` and `client/` at boot.
- **CI `e2e` job**: host runner (no Playwright container) + cached bun deps + cached Playwright browsers keyed by `node_modules/playwright/package.json` version via `jq`. `install-deps` always runs; `install` only on cache miss.
- **Deploy Main + PR Preview**: buildx + `type=gha` cache; binary compiled in builder stage (Strategy A — drops the dead runner-compile step).
- **`.dockerignore`**: excludes dev/test artifacts; uses `data/*.sqlite*` (not `data/`) so the `localizations.json` seed stays in context.
- **README**: documents the new e2e runtime. Update Snapshots section untouched.

## Test plan

- [x] `bun run check` (tsgo) — clean
- [x] `bunx oxlint .` — 0 warnings, 0 errors
- [x] `bunx oxfmt . --check` — all formatted
- [x] `bun run test` — 986 pass / 7 skip / 0 fail (added 4 path-resolution tests in `test/server/path-resolution.test.js`)
- [x] `bun scripts/check-changeset.js` — valid changeset
- [ ] Docker smoke (real build) — needs Docker daemon
- [ ] CI verification — needs a real Actions run on this PR